### PR TITLE
feat(manager): add SimState period configuration

### DIFF
--- a/examples/simconnect-state/main.go
+++ b/examples/simconnect-state/main.go
@@ -121,7 +121,7 @@ func handleMessage(msg engine.Message) {
 	}
 
 	if shouldPrintMessage {
-		fmt.Println("📨 Message received - ", types.SIMCONNECT_RECV_ID(msg.SIMCONNECT_RECV.DwID))
+		//fmt.Println("📨 Message received - ", types.SIMCONNECT_RECV_ID(msg.SIMCONNECT_RECV.DwID))
 	}
 
 	// Handle specific messages
@@ -223,6 +223,9 @@ func main() {
 		manager.WithAutoReconnect(true),
 		manager.WithBufferSize(512),  // Optional: increase buffer for high-frequency data
 		manager.WithHeartbeat("6Hz"), // Optional: set heartbeat frequency
+		// Optional: set SimState update frequency (default: every sim frame)
+		// Use types.SIMCONNECT_PERIOD_SECOND for lower CPU usage (1Hz updates)
+		// manager.WithSimStatePeriod(types.SIMCONNECT_PERIOD_SECOND),
 	)
 
 	// Setup signal handler goroutine - calls mgr.Stop() for graceful shutdown

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mrlm-net/simconnect/internal/dll"
 	"github.com/mrlm-net/simconnect/pkg/engine"
 	"github.com/mrlm-net/simconnect/pkg/manager"
+	"github.com/mrlm-net/simconnect/pkg/types"
 )
 
 // DetectDLLPath searches for SimConnect.dll on the local filesystem.
@@ -169,6 +170,19 @@ func WithMaxRetries(n int) manager.Option {
 // Default is true.
 func WithAutoReconnect(enabled bool) manager.Option {
 	return manager.WithAutoReconnect(enabled)
+}
+
+// WithSimStatePeriod sets the update frequency for internal SimState data requests.
+// Controls how often the manager polls simulator state variables.
+//
+// Supported values:
+//   - types.SIMCONNECT_PERIOD_SIM_FRAME — every simulation frame (default)
+//   - types.SIMCONNECT_PERIOD_VISUAL_FRAME — every visual frame
+//   - types.SIMCONNECT_PERIOD_SECOND — once per second (1Hz)
+//   - types.SIMCONNECT_PERIOD_ONCE — single snapshot
+//   - types.SIMCONNECT_PERIOD_NEVER — disable SimState requests
+func WithSimStatePeriod(period types.SIMCONNECT_PERIOD) manager.Option {
+	return manager.WithSimStatePeriod(period)
 }
 
 // WithEngineOptions passes options through to the underlying engine.

--- a/pkg/manager/config.go
+++ b/pkg/manager/config.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/mrlm-net/simconnect/pkg/engine"
+	"github.com/mrlm-net/simconnect/pkg/types"
 )
 
 const (
@@ -42,6 +43,11 @@ type Config struct {
 
 	// Behavior settings
 	AutoReconnect bool // Whether to automatically reconnect on disconnect
+
+	// SimStatePeriod controls how often the manager requests SimState data from SimConnect.
+	// Default is SIMCONNECT_PERIOD_SIM_FRAME (every simulation frame).
+	// Use SIMCONNECT_PERIOD_SECOND for lower-frequency updates (1Hz) to reduce CPU usage.
+	SimStatePeriod types.SIMCONNECT_PERIOD
 
 	// Engine options to pass through
 	EngineOptions []engine.Option
@@ -121,6 +127,21 @@ func WithAutoReconnect(enabled bool) Option {
 	}
 }
 
+// WithSimStatePeriod sets the update frequency for internal SimState data requests.
+// Controls how often the manager polls simulator state variables (camera, position, weather, etc.).
+//
+// Supported values:
+//   - types.SIMCONNECT_PERIOD_SIM_FRAME — every simulation frame (~30-60Hz, default)
+//   - types.SIMCONNECT_PERIOD_VISUAL_FRAME — every visual frame
+//   - types.SIMCONNECT_PERIOD_SECOND — once per second (1Hz, lower CPU usage)
+//   - types.SIMCONNECT_PERIOD_ONCE — single snapshot (no periodic updates)
+//   - types.SIMCONNECT_PERIOD_NEVER — disable SimState data requests entirely
+func WithSimStatePeriod(period types.SIMCONNECT_PERIOD) Option {
+	return func(c *Config) {
+		c.SimStatePeriod = period
+	}
+}
+
 // WithEngineOptions passes options through to the underlying engine.
 // Note: Context and Logger options passed here will be ignored as the manager
 // controls these settings. Use WithContext and WithLogger on the manager instead.
@@ -180,6 +201,7 @@ func defaultConfig() *Config {
 		ShutdownTimeout:   DEFAULT_SHUTDOWN_TIMEOUT,
 		MaxRetries:        DEFAULT_MAX_RETRIES,
 		AutoReconnect:     DEFAULT_AUTO_RECONNECT,
+		SimStatePeriod:    types.SIMCONNECT_PERIOD_SIM_FRAME,
 		EngineOptions:     []engine.Option{},
 	}
 }

--- a/pkg/manager/getters.go
+++ b/pkg/manager/getters.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/mrlm-net/simconnect/pkg/engine"
+	"github.com/mrlm-net/simconnect/pkg/types"
 )
 
 // State returns the current connection state
@@ -57,4 +58,9 @@ func (m *Instance) ShutdownTimeout() time.Duration {
 // MaxRetries returns the maximum number of connection retries (0 = unlimited)
 func (m *Instance) MaxRetries() int {
 	return m.config.MaxRetries
+}
+
+// SimStatePeriod returns the configured SimState data request period
+func (m *Instance) SimStatePeriod() types.SIMCONNECT_PERIOD {
+	return m.config.SimStatePeriod
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -242,6 +242,9 @@ type Manager interface {
 	// MaxRetries returns the maximum number of connection retries (0 = unlimited)
 	MaxRetries() int
 
+	// SimStatePeriod returns the configured SimState data request period
+	SimStatePeriod() types.SIMCONNECT_PERIOD
+
 	// RemoveStateChange removes a previously registered state change handler by id.
 	// Returns an error if the id is unknown.
 	RemoveConnectionStateChange(id string) error

--- a/pkg/manager/simstate_registration.go
+++ b/pkg/manager/simstate_registration.go
@@ -266,8 +266,12 @@ func (m *Instance) registerSimStateSubscriptions(client engine.Client) {
 		m.logger.Error("[manager] Failed to add SEA LEVEL AMBIENT TEMPERATURE definition", "error", err)
 	}
 
-	// Request camera data with period matching heartbeat configuration
-	period := types.SIMCONNECT_PERIOD_SIM_FRAME
+	// Request camera data with period from configuration
+	period := m.config.SimStatePeriod
+	if period == types.SIMCONNECT_PERIOD_NEVER {
+		m.logger.Warn("[manager] SimStatePeriod set to NEVER — SimState tracking disabled, change notifications will not fire")
+		return
+	}
 	m.requestRegistry.Register(m.cameraRequestID, RequestTypeDataRequest, "Simulator State Data Request")
 	if err := client.RequestDataOnSimObject(m.cameraRequestID, m.cameraDefinitionID, types.SIMCONNECT_OBJECT_ID_USER, period, types.SIMCONNECT_DATA_REQUEST_FLAG_DEFAULT, 0, 0, 0); err != nil {
 		m.logger.Error("[manager] Failed to request camera data", "error", err)


### PR DESCRIPTION
## Summary
- Add `WithSimStatePeriod()` functional option to configure SimState data request frequency
- Default to `SIMCONNECT_PERIOD_SIM_FRAME` (backward compatible — no behavior change)
- Support all `SIMCONNECT_PERIOD` values: `SIM_FRAME`, `VISUAL_FRAME`, `SECOND`, `ONCE`, `NEVER`
- Warn and skip data request when period is `NEVER` (disables SimState tracking)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet -unsafeptr=false ./...` passes
- [x] All 27 examples compile
- [x] Default behavior unchanged (SIM_FRAME when no option provided)
- [ ] Manual test with MSFS: verify `WithSimStatePeriod(types.SIMCONNECT_PERIOD_SECOND)` reduces update rate

Closes #28
Part of #19