### PR TITLE
feat(manager): add View and FlightPlanDeactivated event subscriptions

### DIFF
--- a/pkg/manager/ids.go
+++ b/pkg/manager/ids.go
@@ -36,6 +36,8 @@ const (
 	CrashedEventID    uint32 = 999999991 // Manager ID for tracking 'Crashed' system event
 	CrashResetEventID uint32 = 999999990 // Manager ID for tracking 'Crash Reset' system event
 	SoundEventID      uint32 = 999999989 // Manager ID for tracking 'Sound' system event
+	ViewEventID                    uint32 = 999999988 // Manager ID for tracking 'View' system event
+	FlightPlanDeactivatedEventID   uint32 = 999999987 // Manager ID for tracking 'FlightPlanDeactivated' system event
 
 	// Additional Manager Event IDs
 	// These IDs map internal manager subscriptions for SimConnect system events.

--- a/pkg/manager/main.go
+++ b/pkg/manager/main.go
@@ -140,6 +140,10 @@ func New(name string, opts ...Option) Manager {
 		crashedHandlers:              []crashedHandlerEntry{},
 		crashResetHandlers:           []crashResetHandlerEntry{},
 		soundEventHandlers:           []soundEventHandlerEntry{},
+		viewEventID:                    ViewEventID,
+		flightPlanDeactivatedEventID:   FlightPlanDeactivatedEventID,
+		viewHandlers:                    []viewHandlerEntry{},
+		flightPlanDeactivatedHandlers:   []flightPlanDeactivatedHandlerEntry{},
 		requestRegistry:              NewRequestRegistry(),
 	}
 }
@@ -202,6 +206,11 @@ type Instance struct {
 	crashResetEventID  uint32
 	soundEventID       uint32
 
+	viewHandlers                    []viewHandlerEntry
+	flightPlanDeactivatedHandlers   []flightPlanDeactivatedHandlerEntry
+	viewEventID                    uint32
+	flightPlanDeactivatedEventID   uint32
+
 	// Request tracking
 	requestRegistry *RequestRegistry // Tracks active SimConnect requests for correlation with responses
 
@@ -217,6 +226,8 @@ type Instance struct {
 	crashedHandlersBuf      []CrashedHandler
 	crashResetHandlersBuf   []CrashResetHandler
 	soundEventHandlersBuf   []SoundEventHandler
+	viewHandlersBuf                    []ViewHandler
+	flightPlanDeactivatedHandlersBuf   []FlightPlanDeactivatedHandler
 	flightLoadedHandlersBuf []FlightLoadedHandler
 	objectChangeHandlersBuf []ObjectChangeHandler
 	stateSubsBuf            []*connectionStateSubscription
@@ -284,6 +295,22 @@ type SoundEventHandler func(soundID uint32)
 type soundEventHandlerEntry struct {
 	id string
 	fn SoundEventHandler
+}
+
+// View event handler type — called when the camera view changes
+type ViewHandler func(viewID uint32)
+
+type viewHandlerEntry struct {
+	id string
+	fn ViewHandler
+}
+
+// FlightPlanDeactivated handler type — called when the active flight plan is deactivated
+type FlightPlanDeactivatedHandler func()
+
+type flightPlanDeactivatedHandlerEntry struct {
+	id string
+	fn FlightPlanDeactivatedHandler
 }
 
 // openHandlerEntry stores a connection open handler with an identifier

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -161,6 +161,8 @@ type Manager interface {
 	SubscribeOnCrashed(id string, bufferSize int) Subscription
 	SubscribeOnCrashReset(id string, bufferSize int) Subscription
 	SubscribeOnSoundEvent(id string, bufferSize int) Subscription
+	SubscribeOnView(id string, bufferSize int) Subscription
+	SubscribeOnFlightPlanDeactivated(id string, bufferSize int) Subscription
 
 	// Callback-style handlers for system events (convenience helpers)
 	OnFlightLoaded(handler FlightLoadedHandler) string
@@ -175,6 +177,12 @@ type Manager interface {
 
 	OnSoundEvent(handler SoundEventHandler) string
 	RemoveSoundEvent(id string) error
+
+	OnView(handler ViewHandler) string
+	RemoveView(id string) error
+
+	OnFlightPlanDeactivated(handler FlightPlanDeactivatedHandler) string
+	RemoveFlightPlanDeactivated(id string) error
 
 	OnAircraftLoaded(handler FlightLoadedHandler) string
 	RemoveAircraftLoaded(id string) error

--- a/pkg/manager/simstate_registration.go
+++ b/pkg/manager/simstate_registration.go
@@ -68,6 +68,16 @@ func (m *Instance) registerSimStateSubscriptions(client engine.Client) {
 		m.logger.Error("[manager] Failed to subscribe to Sound event", "error", err)
 	}
 
+	m.requestRegistry.Register(m.viewEventID, RequestTypeEvent, "View Event Subscription")
+	if err := client.SubscribeToSystemEvent(m.viewEventID, "View"); err != nil {
+		m.logger.Error("[manager] Failed to subscribe to View event", "error", err)
+	}
+
+	m.requestRegistry.Register(m.flightPlanDeactivatedEventID, RequestTypeEvent, "FlightPlanDeactivated Event Subscription")
+	if err := client.SubscribeToSystemEvent(m.flightPlanDeactivatedEventID, "FlightPlanDeactivated"); err != nil {
+		m.logger.Error("[manager] Failed to subscribe to FlightPlanDeactivated event", "error", err)
+	}
+
 	// Define camera data structure
 	m.requestRegistry.Register(m.cameraDefinitionID, RequestTypeDataDefinition, "Simulator State Definition")
 	if err := client.AddToDataDefinition(m.cameraDefinitionID, "CAMERA STATE", "", types.SIMCONNECT_DATATYPE_INT32, 0, 0); err != nil {


### PR DESCRIPTION
## Summary
- Audited manager system event coverage against SimConnect SDK
- Added **View** event subscription (camera view changes, carries `viewID uint32`)
- Added **FlightPlanDeactivated** event subscription (void event, complement to FlightPlanActivated)
- Rejected WeatherModeChanged — not a real SimConnect SDK system event (weather tracked via SimVars)

Closes #29

## Changes
| File | What |
|------|------|
| `pkg/manager/ids.go` | ViewEventID=999999988, FlightPlanDeactivatedEventID=999999987 |
| `pkg/manager/main.go` | Handler types, entry structs, Instance fields, constructor init |
| `pkg/manager/simstate_registration.go` | Event subscriptions in registerSimStateSubscriptions |
| `pkg/manager/dispatch.go` | Dispatch routing (RLock, pre-allocated buffers, safeCallHandler) |
| `pkg/manager/handlers.go` | On/Remove/Subscribe methods for both events |
| `pkg/manager/manager.go` | Manager interface updated |
| `docs/usage-manager.md` | Documentation with callback and subscription examples |

## Quality Gates
- Code Review: **APPROVE** (zero critical issues)
- Tests: **ALL PASS** (build, vet, unit tests)
- Security: **RELEASE CLEARANCE YES** (0 vulnerabilities)

## Test plan
- [ ] Verify `go build ./...` passes
- [ ] Verify `go vet -unsafeptr=false ./...` passes
- [ ] Verify View event fires when switching camera views in MSFS
- [ ] Verify FlightPlanDeactivated fires when clearing flight plan in MSFS