### PR TITLE
feat(manager): standardize dual event API with custom event support

### DIFF
--- a/docs/manager-requests-ids.md
+++ b/docs/manager-requests-ids.md
@@ -10,8 +10,9 @@ The manager uses a **high-number ID reservation strategy** to maximize flexibili
 
 | Range | Owner | Count | Purpose |
 |-------|-------|-------|---------|
-| 1 - 999,999,899 | **User Applications** | 999,999,899 | User-defined data definitions and requests |
-| 999,999,900 - 999,999,999 | **Manager** | 100 | Internal manager operations (reserved) |
+| 1 - 999,999,849 | **User Applications** | 999,999,849 | User-defined data definitions and requests |
+| 999,999,850 - 999,999,886 | **Manager** | 37 | Custom system event IDs (dynamic allocation) |
+| 999,999,887 - 999,999,999 | **Manager** | 113 | Internal manager operations (reserved) |
 
 ### Why High Numbers for Manager?
 
@@ -62,21 +63,36 @@ The manager's simulator state data definition now includes additional environmen
 The manager reserves specific high-number IDs for internal system event subscriptions. These are registered on connection open and used for request tracking; the actual SimConnect system event names are standard (e.g. "Pause", "Sim", "FlightLoaded").
 
 ```go
-PauseEventID                 = 999999998 // Pause/unpause event subscription
-SimEventID                   = 999999997 // Sim start/stop event subscription
-FlightLoadedEventID          = 999999996 // Flight file loaded (filename returned)
-AircraftLoadedEventID        = 999999995 // Aircraft file loaded/changed (.AIR)
-ObjectAddedEventID           = 999999994 // AI object added
-ObjectRemovedEventID         = 999999993 // AI object removed
-FlightPlanActivatedEventID   = 999999992 // Flight plan activated (filename returned)
+PauseEventID                 = 999999999 // Pause/unpause event subscription
+SimEventID                   = 999999998 // Sim start/stop event subscription
+FlightLoadedEventID          = 999999997 // Flight file loaded (filename returned)
+AircraftLoadedEventID        = 999999996 // Aircraft file loaded/changed (.AIR)
+ObjectAddedEventID           = 999999995 // AI object added
+ObjectRemovedEventID         = 999999994 // AI object removed
+FlightPlanActivatedEventID   = 999999993 // Flight plan activated (filename returned)
+FlightPlanDeactivatedEventID = 999999992 // Flight plan deactivated
 CrashedEventID               = 999999991 // Simulator crashed (manager reserved ID)
 CrashResetEventID            = 999999990 // Crash reset event (manager reserved ID)
 SoundEventID                 = 999999989 // Sound event (manager reserved ID)
+ViewEventID                  = 999999988 // View camera event (manager reserved ID)
 ```
 
 **Purpose**: These IDs are used to register and track the manager's internal subscriptions to SimConnect system events. Responses may arrive as different `SIMCONNECT_RECV` variants (e.g., `SIMCONNECT_RECV_EVENT`, `SIMCONNECT_RECV_EVENT_FILENAME`, `SIMCONNECT_RECV_EVENT_OBJECT_ADDREMOVE`).
 
 **Usage**: Internal to the manager. The manager updates `SimState` for Pause/Sim events and provides typed subscription helpers for filename/object events.
+
+### Custom Event System (manager-reserved ID range)
+
+The manager reserves a range of IDs for user-defined custom system events:
+
+```go
+CustomEventIDMin = 999999850 // First ID for custom events
+CustomEventIDMax = 999999886 // Last ID for custom events (37 slots total)
+```
+
+**Purpose**: These IDs are dynamically allocated when users subscribe to custom SimConnect system events by name (e.g., "6Hz", "1sec"). Custom events use the `SubscribeToCustomSystemEvent` and `OnCustomSystemEvent` APIs.
+
+**Usage**: Managed internally by the manager. Custom event subscriptions are automatically cleared on disconnect and are not persisted across reconnection cycles.
 
 ## Request Registry
 

--- a/pkg/manager/custom_events.go
+++ b/pkg/manager/custom_events.go
@@ -1,0 +1,181 @@
+//go:build windows
+
+package manager
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/mrlm-net/simconnect/pkg/engine"
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+var (
+	// ErrReservedEventName is returned when attempting to register a custom event with a reserved name
+	ErrReservedEventName = errors.New("manager: event name is reserved for internal use")
+
+	// ErrCustomEventNotFound is returned when attempting to unsubscribe from a non-existent custom event
+	ErrCustomEventNotFound = errors.New("manager: custom event not found")
+
+	// ErrCustomEventIDExhausted is returned when the custom event ID pool is exhausted
+	ErrCustomEventIDExhausted = errors.New("manager: custom event ID pool exhausted")
+
+	// ErrCustomEventNotSubscribed is returned when attempting to register a handler for an unsubscribed event
+	ErrCustomEventNotSubscribed = errors.New("manager: custom event not subscribed")
+
+	// ErrCustomEventHandlerNotFound is returned when attempting to remove a non-existent handler
+	ErrCustomEventHandlerNotFound = errors.New("manager: custom event handler not found")
+)
+
+// reservedSystemEvents contains all internal event names that cannot be used as custom events
+var reservedSystemEvents = map[string]bool{
+	"Pause":                 true,
+	"Sim":                   true,
+	"FlightLoaded":          true,
+	"AircraftLoaded":        true,
+	"ObjectAdded":           true,
+	"ObjectRemoved":         true,
+	"FlightPlanActivated":   true,
+	"Crashed":               true,
+	"CrashReset":            true,
+	"Sound":                 true,
+	"View":                  true,
+	"FlightPlanDeactivated": true,
+}
+
+// SubscribeToCustomSystemEvent subscribes to a custom system event by name.
+// The event must not conflict with reserved internal event names.
+// Returns a filtered Subscription that delivers only messages for this event.
+func (m *Instance) SubscribeToCustomSystemEvent(eventName string, bufferSize int) (Subscription, error) {
+	if reservedSystemEvents[eventName] {
+		return nil, ErrReservedEventName
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Check if already subscribed
+	if _, exists := m.customSystemEvents[eventName]; exists {
+		// Already subscribed, return existing subscription
+		filter := func(msg engine.Message) bool {
+			if types.SIMCONNECT_RECV_ID(msg.DwID) != types.SIMCONNECT_RECV_ID_EVENT {
+				return false
+			}
+			ev := msg.AsEvent()
+			return ev != nil && ev.UEventID == types.DWORD(m.customSystemEvents[eventName].id)
+		}
+		return m.SubscribeWithFilter(eventName+"-custom", bufferSize, filter), nil
+	}
+
+	// Allocate new event ID
+	eventID, err := m.allocateCustomEventIDLocked()
+	if err != nil {
+		return nil, err
+	}
+
+	// Subscribe via engine
+	if m.engine == nil {
+		return nil, ErrNotConnected
+	}
+
+	if err := m.engine.SubscribeToSystemEvent(eventID, eventName); err != nil {
+		return nil, fmt.Errorf("manager: failed to subscribe to custom system event '%s': %w", eventName, err)
+	}
+
+	// Store custom event
+	m.customSystemEvents[eventName] = &customSystemEvent{
+		name:     eventName,
+		id:       eventID,
+		handlers: []customSystemEventHandlerEntry{},
+	}
+
+	m.logger.Debug("[manager] Subscribed to custom system event", "event", eventName, "id", eventID)
+
+	// Return filtered subscription
+	filter := func(msg engine.Message) bool {
+		if types.SIMCONNECT_RECV_ID(msg.DwID) != types.SIMCONNECT_RECV_ID_EVENT {
+			return false
+		}
+		ev := msg.AsEvent()
+		return ev != nil && ev.UEventID == types.DWORD(eventID)
+	}
+	return m.SubscribeWithFilter(eventName+"-custom", bufferSize, filter), nil
+}
+
+// UnsubscribeFromCustomSystemEvent unsubscribes from a custom system event.
+func (m *Instance) UnsubscribeFromCustomSystemEvent(eventName string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ce, exists := m.customSystemEvents[eventName]
+	if !exists {
+		return ErrCustomEventNotFound
+	}
+
+	// Unsubscribe via engine
+	if m.engine != nil {
+		if err := m.engine.UnsubscribeFromSystemEvent(ce.id); err != nil {
+			return fmt.Errorf("manager: failed to unsubscribe from custom system event '%s': %w", eventName, err)
+		}
+	}
+
+	// Remove from map
+	delete(m.customSystemEvents, eventName)
+
+	m.logger.Debug("[manager] Unsubscribed from custom system event", "event", eventName, "id", ce.id)
+	return nil
+}
+
+// OnCustomSystemEvent registers a callback handler for a custom system event.
+// The event must be subscribed first via SubscribeToCustomSystemEvent.
+func (m *Instance) OnCustomSystemEvent(eventName string, handler CustomSystemEventHandler) (string, error) {
+	if reservedSystemEvents[eventName] {
+		return "", ErrReservedEventName
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ce, exists := m.customSystemEvents[eventName]
+	if !exists {
+		return "", ErrCustomEventNotSubscribed
+	}
+
+	id := generateUUID()
+	ce.handlers = append(ce.handlers, customSystemEventHandlerEntry{id: id, fn: handler})
+
+	m.logger.Debug("[manager] Registered custom system event handler", "event", eventName, "id", id)
+	return id, nil
+}
+
+// RemoveCustomSystemEvent removes a callback handler for a custom system event.
+func (m *Instance) RemoveCustomSystemEvent(eventName string, handlerID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ce, exists := m.customSystemEvents[eventName]
+	if !exists {
+		return ErrCustomEventNotFound
+	}
+
+	for i, e := range ce.handlers {
+		if e.id == handlerID {
+			ce.handlers = append(ce.handlers[:i], ce.handlers[i+1:]...)
+			m.logger.Debug("[manager] Removed custom system event handler", "event", eventName, "handlerID", handlerID)
+			return nil
+		}
+	}
+
+	return ErrCustomEventHandlerNotFound
+}
+
+// allocateCustomEventIDLocked allocates the next available custom event ID.
+// Must be called with m.mu held.
+func (m *Instance) allocateCustomEventIDLocked() (uint32, error) {
+	if m.customEventIDAlloc > CustomEventIDMax {
+		return 0, ErrCustomEventIDExhausted
+	}
+	id := m.customEventIDAlloc
+	m.customEventIDAlloc++
+	return id, nil
+}

--- a/pkg/manager/handlers.go
+++ b/pkg/manager/handlers.go
@@ -508,3 +508,89 @@ func (m *Instance) RemoveSimStateChange(id string) error {
 	}
 	return fmt.Errorf("SimState handler not found: %s", id)
 }
+
+// OnPause registers a callback invoked when the simulator pause state changes.
+func (m *Instance) OnPause(handler PauseHandler) string {
+	id := generateUUID()
+	m.mu.Lock()
+	m.pauseHandlers = append(m.pauseHandlers, pauseHandlerEntry{id: id, fn: handler})
+	m.mu.Unlock()
+	if m.logger != nil {
+		m.logger.Debug("[manager] Registered Pause handler", "id", id)
+	}
+	return id
+}
+
+// RemovePause removes a previously registered Pause handler.
+func (m *Instance) RemovePause(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, e := range m.pauseHandlers {
+		if e.id == id {
+			m.pauseHandlers = append(m.pauseHandlers[:i], m.pauseHandlers[i+1:]...)
+			if m.logger != nil {
+				m.logger.Debug("[manager] Removed Pause handler", "id", id)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("Pause handler not found: %s", id)
+}
+
+// SubscribeOnPause returns a subscription that receives raw engine.Message for Pause events
+func (m *Instance) SubscribeOnPause(id string, bufferSize int) Subscription {
+	if id == "" {
+		id = generateUUID()
+	}
+	filter := func(msg engine.Message) bool {
+		if types.SIMCONNECT_RECV_ID(msg.DwID) != types.SIMCONNECT_RECV_ID_EVENT {
+			return false
+		}
+		ev := msg.AsEvent()
+		return ev != nil && ev.UEventID == types.DWORD(m.pauseEventID)
+	}
+	return m.SubscribeWithFilter(id+"-pause", bufferSize, filter)
+}
+
+// OnSimRunning registers a callback invoked when the simulator running state changes.
+func (m *Instance) OnSimRunning(handler SimRunningHandler) string {
+	id := generateUUID()
+	m.mu.Lock()
+	m.simRunningHandlers = append(m.simRunningHandlers, simRunningHandlerEntry{id: id, fn: handler})
+	m.mu.Unlock()
+	if m.logger != nil {
+		m.logger.Debug("[manager] Registered SimRunning handler", "id", id)
+	}
+	return id
+}
+
+// RemoveSimRunning removes a previously registered SimRunning handler.
+func (m *Instance) RemoveSimRunning(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, e := range m.simRunningHandlers {
+		if e.id == id {
+			m.simRunningHandlers = append(m.simRunningHandlers[:i], m.simRunningHandlers[i+1:]...)
+			if m.logger != nil {
+				m.logger.Debug("[manager] Removed SimRunning handler", "id", id)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("SimRunning handler not found: %s", id)
+}
+
+// SubscribeOnSimRunning returns a subscription that receives raw engine.Message for Sim running events
+func (m *Instance) SubscribeOnSimRunning(id string, bufferSize int) Subscription {
+	if id == "" {
+		id = generateUUID()
+	}
+	filter := func(msg engine.Message) bool {
+		if types.SIMCONNECT_RECV_ID(msg.DwID) != types.SIMCONNECT_RECV_ID_EVENT {
+			return false
+		}
+		ev := msg.AsEvent()
+		return ev != nil && ev.UEventID == types.DWORD(m.simEventID)
+	}
+	return m.SubscribeWithFilter(id+"-simrunning", bufferSize, filter)
+}

--- a/pkg/manager/ids.go
+++ b/pkg/manager/ids.go
@@ -48,9 +48,14 @@ const (
 	FlightPlanActivatedEventID uint32 = 999999992 // Flight plan activated
 	// Position change event removed
 
+	// Custom System Event Range — dynamically allocated for user-defined system events
+	CustomEventIDMin uint32 = 999999850
+	CustomEventIDMax uint32 = 999999886
+
 	// ID Range Documentation:
 	// User-Available Range: 1 - 999999899 (999,999,899 IDs available for user requests)
 	// Manager Reserved Range: 999999900 - 999999999 (100 IDs reserved for manager operations)
+	// Custom Event Range: 999999850 - 999999886 (37 IDs for custom system events)
 )
 
 // IDRange defines the boundaries for ID allocation

--- a/pkg/manager/lifecycle.go
+++ b/pkg/manager/lifecycle.go
@@ -185,6 +185,12 @@ func (m *Instance) disconnect() {
 		}
 	}
 
+	// Clear custom system events on disconnect
+	m.mu.Lock()
+	m.customSystemEvents = make(map[string]*customSystemEvent)
+	m.customEventIDAlloc = CustomEventIDMin
+	m.mu.Unlock()
+
 	// Clean up request registry on disconnect
 	m.requestRegistry.Clear()
 

--- a/pkg/manager/main.go
+++ b/pkg/manager/main.go
@@ -144,6 +144,10 @@ func New(name string, opts ...Option) Manager {
 		flightPlanDeactivatedEventID:   FlightPlanDeactivatedEventID,
 		viewHandlers:                    []viewHandlerEntry{},
 		flightPlanDeactivatedHandlers:   []flightPlanDeactivatedHandlerEntry{},
+		pauseHandlers:          []pauseHandlerEntry{},
+		simRunningHandlers:     []simRunningHandlerEntry{},
+		customSystemEvents:     make(map[string]*customSystemEvent),
+		customEventIDAlloc:     CustomEventIDMin,
 		requestRegistry:              NewRequestRegistry(),
 	}
 }
@@ -211,6 +215,13 @@ type Instance struct {
 	viewEventID                    uint32
 	flightPlanDeactivatedEventID   uint32
 
+	pauseHandlers          []pauseHandlerEntry
+	simRunningHandlers     []simRunningHandlerEntry
+
+	// Custom system events
+	customSystemEvents     map[string]*customSystemEvent
+	customEventIDAlloc     uint32
+
 	// Request tracking
 	requestRegistry *RequestRegistry // Tracks active SimConnect requests for correlation with responses
 
@@ -228,6 +239,8 @@ type Instance struct {
 	soundEventHandlersBuf   []SoundEventHandler
 	viewHandlersBuf                    []ViewHandler
 	flightPlanDeactivatedHandlersBuf   []FlightPlanDeactivatedHandler
+	pauseHandlersBuf       []PauseHandler
+	simRunningHandlersBuf  []SimRunningHandler
 	flightLoadedHandlersBuf []FlightLoadedHandler
 	objectChangeHandlersBuf []ObjectChangeHandler
 	stateSubsBuf            []*connectionStateSubscription
@@ -312,6 +325,37 @@ type flightPlanDeactivatedHandlerEntry struct {
 	id string
 	fn FlightPlanDeactivatedHandler
 }
+
+// PauseHandler is invoked when the simulator pause state changes
+type PauseHandler func(paused bool)
+
+type pauseHandlerEntry struct {
+	id string
+	fn PauseHandler
+}
+
+// SimRunningHandler is invoked when the simulator running state changes
+type SimRunningHandler func(running bool)
+
+type simRunningHandlerEntry struct {
+	id string
+	fn SimRunningHandler
+}
+
+// customSystemEvent tracks a user-registered custom system event
+type customSystemEvent struct {
+	name     string
+	id       uint32
+	handlers []customSystemEventHandlerEntry
+}
+
+type customSystemEventHandlerEntry struct {
+	id string
+	fn CustomSystemEventHandler
+}
+
+// CustomSystemEventHandler is invoked when a custom system event fires
+type CustomSystemEventHandler func(eventName string, data uint32)
 
 // openHandlerEntry stores a connection open handler with an identifier
 type openHandlerEntry struct {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -196,6 +196,22 @@ type Manager interface {
 	OnObjectRemoved(handler ObjectChangeHandler) string
 	RemoveObjectRemoved(id string) error
 
+	// Pause event dual API
+	OnPause(handler PauseHandler) string
+	RemovePause(id string) error
+	SubscribeOnPause(id string, bufferSize int) Subscription
+
+	// Sim running event dual API
+	OnSimRunning(handler SimRunningHandler) string
+	RemoveSimRunning(id string) error
+	SubscribeOnSimRunning(id string, bufferSize int) Subscription
+
+	// Custom system event API
+	SubscribeToCustomSystemEvent(eventName string, bufferSize int) (Subscription, error)
+	UnsubscribeFromCustomSystemEvent(eventName string) error
+	OnCustomSystemEvent(eventName string, handler CustomSystemEventHandler) (string, error)
+	RemoveCustomSystemEvent(eventName string, handlerID string) error
+
 	// Client returns the underlying engine client for direct API access.
 	// Returns nil if not connected.
 	Client() engine.Client


### PR DESCRIPTION
## Summary
- All 12 system events now have consistent dual API: callback (`On<Event>`) + channel subscription (`SubscribeOn<Event>`)
- Added **OnPause/OnSimRunning** callbacks with pre-allocated handler buffers
- Added **SubscribeOnPause/SubscribeOnSimRunning** channel subscriptions
- New **custom system event API** for user-defined events with reserved name validation and bounded ID allocation

Closes #30

## Changes
| File | What |
|------|------|
| `pkg/manager/custom_events.go` | **NEW** — Custom event API: subscribe, unsubscribe, callback, remove, ID allocation |
| `pkg/manager/ids.go` | CustomEventIDMin=999999850, CustomEventIDMax=999999886 (37 slots) |
| `pkg/manager/main.go` | PauseHandler, SimRunningHandler, CustomSystemEventHandler types + Instance fields |
| `pkg/manager/dispatch.go` | Pause/Sim handler dispatch + custom event default case |
| `pkg/manager/handlers.go` | On/Remove/Subscribe for Pause and SimRunning |
| `pkg/manager/manager.go` | Manager interface: 10 new methods |
| `pkg/manager/lifecycle.go` | Custom event cleanup on disconnect |
| `docs/usage-manager.md` | Pause/Sim/Custom event examples |
| `docs/manager-requests-ids.md` | Custom event ID range documentation |

## Quality Gates
- Code Review: **APPROVE** (zero critical issues)
- Tests: **ALL PASS** (build, vet, unit tests)
- Security: **RELEASE CLEARANCE YES** (0 vulnerabilities)

## Test plan
- [ ] Verify `go build ./...` passes
- [ ] Verify `go vet -unsafeptr=false ./...` passes
- [ ] Verify OnPause fires when pausing/unpausing in MSFS
- [ ] Verify OnSimRunning fires when starting/stopping sim
- [ ] Verify SubscribeToCustomSystemEvent rejects reserved names
- [ ] Verify custom event fires for user-defined events (e.g., "1sec")