### PR TITLE
ci(website): GitHub Actions deploy workflow and README docs links

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,50 @@
+name: Deploy Website
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - run: npm ci
+
+      - run: npm run build
+        env:
+          BASE_PATH: /simconnect
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # mrlm-net/simconnect
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/mrlm-net/simconnect.svg)](https://pkg.go.dev/github.com/mrlm-net/simconnect)
+[![Documentation](https://img.shields.io/badge/docs-mrlm--net.github.io%2Fsimconnect-blue)](https://mrlm-net.github.io/simconnect/)
 
 > **Go wrapper for SimConnect.dll** — build Microsoft Flight Simulator 2020/2024 add-ons with type-safe, zero-dependency Go code.
 
@@ -62,11 +63,13 @@ go run ./examples/<name>
 
 ## Documentation
 
-- **[Client Configuration](docs/config-client.md)** — Engine/Client functional options (buffer size, DLL path, heartbeat, logging)
-- **[Client API Reference](docs/usage-client.md)** — Complete Engine/Client API — data definitions, events, AI traffic, facilities
-- **[Manager Configuration](docs/config-manager.md)** — Manager functional options (auto-reconnect, retry intervals, timeouts)
-- **[Manager Usage](docs/usage-manager.md)** — Lifecycle management, subscriptions, state handling
-- **[Request ID Management](docs/manager-requests-ids.md)** — ID allocation strategy and conflict prevention
+**[mrlm-net.github.io/simconnect](https://mrlm-net.github.io/simconnect/)** — Full documentation website with getting started guide, configuration reference, and usage guides.
+
+- [Client Configuration](https://mrlm-net.github.io/simconnect/docs/config-client) — Engine/Client functional options
+- [Client API Reference](https://mrlm-net.github.io/simconnect/docs/usage-client) — Complete Engine/Client API
+- [Manager Configuration](https://mrlm-net.github.io/simconnect/docs/config-manager) — Manager functional options
+- [Manager Usage](https://mrlm-net.github.io/simconnect/docs/usage-manager) — Lifecycle management, subscriptions, state handling
+- [Request ID Management](https://mrlm-net.github.io/simconnect/docs/manager-requests-ids) — ID allocation strategy and conflict prevention
 
 ## Packages
 


### PR DESCRIPTION
## Summary
- Add `.github/workflows/deploy-website.yml` — builds the SvelteKit site with `BASE_PATH=/simconnect` and deploys via `actions/deploy-pages`
- Workflow triggers: `workflow_dispatch` (manual) and `release` (on published)
- Node 22, npm cache, Ubuntu runner, `pages: write` + `id-token: write` permissions
- Update `README.md` — docs badge linking to `mrlm-net.github.io/simconnect/`, documentation section now links to the website instead of local markdown files

Closes #76, closes #77
Part of #67

## Manual Configuration Required
After merging, the repository owner must:
1. Go to **Settings → Pages → Source** and select **GitHub Actions**
2. Run the workflow manually (Actions → Deploy Website → Run workflow) or publish a release

## Test plan
- [x] `npm run build` succeeds in `website/` directory
- [ ] Verify workflow YAML is valid (will be validated by GitHub on push)
- [ ] After merging + enabling Pages: trigger manual run and confirm site deploys to `https://mrlm-net.github.io/simconnect/`
- [ ] Verify README badge renders and links correctly