### PR TITLE
fix(website): update docs URLs to custom domain simconnect.mrlm.net

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -32,8 +32,6 @@ jobs:
       - run: npm ci
 
       - run: npm run build
-        env:
-          BASE_PATH: /simconnect
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mrlm-net/simconnect
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/mrlm-net/simconnect.svg)](https://pkg.go.dev/github.com/mrlm-net/simconnect)
-[![Documentation](https://img.shields.io/badge/docs-mrlm--net.github.io%2Fsimconnect-blue)](https://mrlm-net.github.io/simconnect/)
+[![Documentation](https://img.shields.io/badge/docs-simconnect.mrlm.net-blue)](https://simconnect.mrlm.net/)
 
 > **Go wrapper for SimConnect.dll** — build Microsoft Flight Simulator 2020/2024 add-ons with type-safe, zero-dependency Go code.
 
@@ -63,13 +63,13 @@ go run ./examples/<name>
 
 ## Documentation
 
-**[mrlm-net.github.io/simconnect](https://mrlm-net.github.io/simconnect/)** — Full documentation website with getting started guide, configuration reference, and usage guides.
+**[simconnect.mrlm.net](https://simconnect.mrlm.net/)** — Full documentation website with getting started guide, configuration reference, and usage guides.
 
-- [Client Configuration](https://mrlm-net.github.io/simconnect/docs/config-client) — Engine/Client functional options
-- [Client API Reference](https://mrlm-net.github.io/simconnect/docs/usage-client) — Complete Engine/Client API
-- [Manager Configuration](https://mrlm-net.github.io/simconnect/docs/config-manager) — Manager functional options
-- [Manager Usage](https://mrlm-net.github.io/simconnect/docs/usage-manager) — Lifecycle management, subscriptions, state handling
-- [Request ID Management](https://mrlm-net.github.io/simconnect/docs/manager-requests-ids) — ID allocation strategy and conflict prevention
+- [Client Configuration](https://simconnect.mrlm.net/docs/config-client) — Engine/Client functional options
+- [Client API Reference](https://simconnect.mrlm.net/docs/usage-client) — Complete Engine/Client API
+- [Manager Configuration](https://simconnect.mrlm.net/docs/config-manager) — Manager functional options
+- [Manager Usage](https://simconnect.mrlm.net/docs/usage-manager) — Lifecycle management, subscriptions, state handling
+- [Request ID Management](https://simconnect.mrlm.net/docs/manager-requests-ids) — ID allocation strategy and conflict prevention
 
 ## Packages
 

--- a/website/README.md
+++ b/website/README.md
@@ -76,7 +76,6 @@ To add a new section, update `sectionMeta` and `sectionOrder` in `src/lib/config
 
 Three custom rehype plugins in `src/lib/plugins/` process markdown during compilation:
 
-- **rehype-highlight.js** -- Syntax highlighting using highlight.js with support for Go, Bash, JSON, YAML, JavaScript, and TypeScript
 - **rehype-slug.js** -- Adds `id` attributes to headings for anchor links and table of contents
 - **rehype-rewrite-links.js** -- Rewrites relative `.md` links to `/docs/<slug>` format and converts `../examples/*` links to GitHub URLs
 
@@ -113,18 +112,12 @@ website/
 
 ## GitHub Pages Deployment
 
-Set the `BASE_PATH` environment variable when building for a non-root deployment path:
-
-```bash
-BASE_PATH="/simconnect" npm run build
-```
-
-This prefixes all internal links and asset paths with the specified base. When deployed at the repository root, leave `BASE_PATH` unset or empty.
+The site is deployed to the custom domain `simconnect.mrlm.net` via GitHub Actions (`deploy-website.yml`). No `BASE_PATH` is needed — the site is served at the domain root.
 
 ## Tech Stack
 
 - [SvelteKit](https://svelte.dev/docs/kit) with `@sveltejs/adapter-static` for static site generation
 - [Tailwind CSS v4](https://tailwindcss.com/) with `@tailwindcss/typography` for prose styling
 - [mdsvex](https://mdsvex.pngwn.io/) for markdown preprocessing in Svelte
-- [highlight.js](https://highlightjs.org/) for syntax highlighting (via custom rehype plugin)
+- [Prism.js](https://prismjs.com/) for syntax highlighting
 - [gray-matter](https://github.com/jonschlinkert/gray-matter) for YAML frontmatter parsing

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,0 +1,1 @@
+simconnect.mrlm.net


### PR DESCRIPTION
## Summary
- Replace all `mrlm-net.github.io/simconnect` references in README.md with `simconnect.mrlm.net` (badge, doc links)
- Remove `BASE_PATH: /simconnect` env from deploy-website.yml build step (custom domain needs no path prefix)

Closes #81, closes #83

## Test plan
- [x] `grep -r "mrlm-net.github.io" .` returns zero matches in tracked files
- [x] `npm run build` in website/ succeeds without BASE_PATH
- [ ] Verify badge link resolves to `https://simconnect.mrlm.net/` after merge
- [ ] Verify doc links (e.g., `/docs/config-client`) resolve correctly after deploy