### PR TITLE
feat(website): sticky TOC, hero badges, and card hover fix

### DIFF
--- a/website/src/app.css
+++ b/website/src/app.css
@@ -121,6 +121,24 @@ body {
 	scroll-margin-top: 5rem;
 }
 
+.prose .not-prose a {
+	color: inherit;
+	text-decoration: none;
+}
+
+.prose .not-prose a:hover {
+	color: inherit;
+	text-decoration: none;
+}
+
+/* Sticky TOC sidebar */
+.toc-aside {
+	position: sticky;
+	top: 4rem;
+	height: calc(100vh - 4rem);
+	align-self: flex-start;
+}
+
 
 /* Prism token colors — GitHub Dark theme */
 .token.comment,

--- a/website/src/lib/components/layout/TableOfContents.svelte
+++ b/website/src/lib/components/layout/TableOfContents.svelte
@@ -4,6 +4,7 @@
 	let { headings }: { headings: TocEntry[] } = $props();
 
 	let activeId = $state('');
+	let anchorRefs: Record<string, HTMLAnchorElement> = $state({});
 
 	$effect(() => {
 		if (typeof IntersectionObserver === 'undefined') return;
@@ -31,6 +32,12 @@
 
 		return () => observer.disconnect();
 	});
+
+	$effect(() => {
+		if (activeId && anchorRefs[activeId]) {
+			anchorRefs[activeId].scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+		}
+	});
 </script>
 
 {#if headings.length > 0}
@@ -50,6 +57,7 @@
 				{@const active = activeId === heading.id}
 				<li style="padding-left: {(heading.depth - 2) * 0.75}rem;">
 					<a
+						bind:this={anchorRefs[heading.id]}
 						href="#{heading.id}"
 						class="block py-0.5 transition-colors"
 						style="color: {active ? 'var(--color-link)' : 'var(--color-text-muted)'};"
@@ -61,3 +69,14 @@
 		</ul>
 	</nav>
 {/if}
+
+<style>
+	nav {
+		overflow-y: auto;
+		scrollbar-width: none;
+	}
+
+	nav::-webkit-scrollbar {
+		display: none;
+	}
+</style>

--- a/website/src/routes/(docs)/docs/[slug]/+page.svelte
+++ b/website/src/routes/(docs)/docs/[slug]/+page.svelte
@@ -15,7 +15,7 @@
 		{@html data.doc.renderedContent}
 	</article>
 
-	<aside class="hidden shrink-0 pr-4 xl:block">
+	<aside class="toc-aside hidden shrink-0 pr-4 xl:block">
 		<TableOfContents headings={data.doc.headings} />
 	</aside>
 </div>

--- a/website/src/routes/(docs)/getting-started/+page.svelte
+++ b/website/src/routes/(docs)/getting-started/+page.svelte
@@ -235,7 +235,7 @@ func main() {
 		</div>
 	</article>
 
-	<aside class="hidden shrink-0 pr-4 xl:block">
+	<aside class="toc-aside hidden shrink-0 pr-4 xl:block">
 		<TableOfContents {headings} />
 	</aside>
 </div>

--- a/website/src/routes/(marketing)/+page.svelte
+++ b/website/src/routes/(marketing)/+page.svelte
@@ -202,6 +202,18 @@ func main() {
 				</div>
 			{/if}
 		</div>
+
+		<div class="mt-6 flex flex-wrap items-center justify-center gap-3">
+			<a href="https://github.com/mrlm-net/simconnect/releases/latest" target="_blank" rel="noopener noreferrer">
+				<img src="https://img.shields.io/github/v/release/mrlm-net/simconnect?style=flat-square&color=58a6ff&label=release" alt="Latest Release" class="h-5" />
+			</a>
+			<a href="https://pkg.go.dev/github.com/mrlm-net/simconnect" target="_blank" rel="noopener noreferrer">
+				<img src="https://img.shields.io/badge/go-reference-007d9c?style=flat-square&logo=go&logoColor=white" alt="Go Reference" class="h-5" />
+			</a>
+			<a href="https://github.com/mrlm-net/simconnect/milestone/4" target="_blank" rel="noopener noreferrer">
+				<img src="https://img.shields.io/github/milestones/progress-percent/mrlm-net/simconnect/4?style=flat-square&color=a5d6ff&label=v0.3.0" alt="v0.3.0 Progress" class="h-5" />
+			</a>
+		</div>
 	</div>
 </section>
 


### PR DESCRIPTION
## Summary
- **#82** — Sticky TOC with auto-scroll: `position: sticky` on aside, hidden scrollbar CSS, `scrollIntoView({ behavior: 'smooth', block: 'nearest' })` triggered by `$effect` on `activeId`
- **#85** — Hero badges: release version, Go reference, and v0.3.0 milestone progress badges below the install command
- **#86** — Card hover fix: reset `.prose .not-prose a` decoration/color so getting-started next-steps cards match HP styling

Closes #82, closes #85, closes #86
Part of #67

## Files Changed
- `website/src/app.css` — `.not-prose a` reset + `.toc-aside` sticky class
- `website/src/lib/components/layout/TableOfContents.svelte` — `anchorRefs` + auto-scroll `$effect` + scoped scrollbar CSS
- `website/src/routes/(docs)/docs/[slug]/+page.svelte` — `toc-aside` class on aside
- `website/src/routes/(docs)/getting-started/+page.svelte` — `toc-aside` class on aside
- `website/src/routes/(marketing)/+page.svelte` — shields.io badges

## Test plan
- [ ] TOC sticks below header on scroll, no visible scrollbar
- [ ] Active TOC link auto-scrolls into view on long pages (e.g., /docs/usage-manager)
- [ ] TOC hidden below `xl` breakpoint
- [ ] Getting-started next-steps cards: no underline, correct colors on hover
- [ ] HP hero shows release, Go reference, and milestone badges
- [ ] Build passes without errors