### PR TITLE
feat(website): dynamic milestone badge and UI polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Custom rehype plugins for syntax highlighting (highlight.js), heading slugs, and relative link rewriting (#69)
 - Responsive layout shell with sidebar navigation, dark terminal-inspired theme, and table of contents (#70)
 - Build-time content pipeline reading `docs/*.md` with frontmatter extraction and prerendered static pages (#71)
+- Dynamic milestone progress badge on landing page fetched client-side from public GitHub API (#89)
+
+### Changed
+
+- Increased content left padding by 2 Tailwind units across all documentation pages (#89)
+- Added `cursor-pointer` to copy button on homepage, accordion panels and filter buttons on examples page (#89)
+
+### Fixed
+
+- Corrected external SimConnect documentation links (Event IDs, SimVars) by removing `/flighting/` from URLs (#89)

--- a/website/src/routes/(docs)/docs/+page.svelte
+++ b/website/src/routes/(docs)/docs/+page.svelte
@@ -44,12 +44,12 @@
 				},
 				{
 					title: 'Event IDs',
-					href: 'https://docs.flightsimulator.com/flighting/html/Programming_Tools/Event_IDs/Event_IDs.htm',
+					href: 'https://docs.flightsimulator.com/html/Programming_Tools/Event_IDs/Event_IDs.htm',
 					description: 'Key event reference'
 				},
 				{
 					title: 'Simulation Variables',
-					href: 'https://docs.flightsimulator.com/flighting/html/Programming_Tools/SimVars/Simulation_Variables.htm',
+					href: 'https://docs.flightsimulator.com/html/Programming_Tools/SimVars/Simulation_Variables.htm',
 					description: 'SimVar reference'
 				}
 			]
@@ -78,7 +78,7 @@
 </svelte:head>
 
 <div class="flex">
-	<div class="min-w-0 flex-1 p-6 lg:p-10">
+	<div class="min-w-0 flex-1 p-6 pl-8 lg:p-10 lg:pl-12">
 		<h1 class="mb-2 text-3xl font-bold" style="color: var(--color-text-primary);">
 			Documentation
 		</h1>

--- a/website/src/routes/(docs)/docs/[slug]/+page.svelte
+++ b/website/src/routes/(docs)/docs/[slug]/+page.svelte
@@ -20,7 +20,7 @@
 </svelte:head>
 
 <div class="flex">
-	<article class="prose max-w-none min-w-0 flex-1 p-6 lg:p-10">
+	<article class="prose max-w-none min-w-0 flex-1 p-6 pl-8 lg:p-10 lg:pl-12">
 		{@html data.doc.renderedContent}
 
 		<!-- Prev/Next navigation -->

--- a/website/src/routes/(docs)/examples/+page.svelte
+++ b/website/src/routes/(docs)/examples/+page.svelte
@@ -46,7 +46,7 @@
 	/>
 </svelte:head>
 
-<div class="p-6 lg:p-10">
+<div class="p-6 pl-8 lg:p-10 lg:pl-12">
 	<h1 class="mb-2 text-3xl font-bold" style="color: var(--color-text-primary);">Examples</h1>
 	<p class="mb-6" style="color: var(--color-text-secondary);">
 		Browse {data.examples.length} example applications covering connections, data reading, events,
@@ -58,7 +58,7 @@
 		{#each categories as cat (cat)}
 			{@const active = activeCategory === cat}
 			<button
-				class="rounded-full px-3 py-1 text-sm font-medium transition-colors"
+				class="cursor-pointer rounded-full px-3 py-1 text-sm font-medium transition-colors"
 				style="background-color: {active
 					? 'var(--color-link)'
 					: 'var(--color-bg-secondary)'}; color: {active
@@ -82,7 +82,7 @@
 				style="border-color: var(--color-border); background-color: var(--color-bg-secondary);"
 			>
 				<button
-					class="flex w-full items-center justify-between p-4 text-left"
+					class="flex w-full cursor-pointer items-center justify-between p-4 text-left"
 					onclick={() => toggle(example.slug)}
 				>
 					<div>

--- a/website/src/routes/(docs)/getting-started/+page.svelte
+++ b/website/src/routes/(docs)/getting-started/+page.svelte
@@ -129,7 +129,7 @@ func main() {
 </svelte:head>
 
 <div class="flex">
-	<article class="prose max-w-none min-w-0 flex-1 p-6 lg:p-10">
+	<article class="prose max-w-none min-w-0 flex-1 p-6 pl-8 lg:p-10 lg:pl-12">
 		<h1>Getting Started</h1>
 		<p>
 			This guide walks you through installing the SimConnect Go SDK and connecting to Microsoft


### PR DESCRIPTION
## Summary
- Replace hardcoded milestone badge (milestone/4, v0.3.0) with client-side fetch from public GitHub API — picks nearest-due open milestone dynamically
- Increase left padding on doc content areas (+2 Tailwind units)
- Add `cursor-pointer` to copy button (homepage), accordion panels and filter buttons (examples page)
- Fix Event IDs and SimVars external links (remove `/flighting/` from URLs)

## Test plan
- [ ] Marketing page: milestone badge loads dynamically with correct milestone
- [ ] Marketing page: shimmer placeholder visible briefly before badge loads
- [ ] Marketing page: badge hidden gracefully when API unreachable
- [ ] Doc pages: left padding visually increased
- [ ] Examples page: cursor-pointer on panels and filter buttons
- [ ] External links point to correct MSFS docs URLs

Closes #89