### PR TITLE
feat(manager): extend Manager interface with event, notification, system, facility, and AI traffic delegation methods

### DIFF
--- a/pkg/manager/ai_traffic.go
+++ b/pkg/manager/ai_traffic.go
@@ -1,0 +1,127 @@
+//go:build windows
+// +build windows
+
+package manager
+
+import "github.com/mrlm-net/simconnect/pkg/types"
+
+// AICreateParkedATCAircraft creates a parked ATC aircraft at an airport.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) AICreateParkedATCAircraft(szContainerTitle string, szTailNumber string, szAirportID string, RequestID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.AICreateParkedATCAircraft(szContainerTitle, szTailNumber, szAirportID, RequestID)
+}
+
+// AISetAircraftFlightPlan assigns a flight plan to an AI aircraft.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) AISetAircraftFlightPlan(objectID uint32, szFlightPlanPath string, requestID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.AISetAircraftFlightPlan(objectID, szFlightPlanPath, requestID)
+}
+
+// AICreateEnrouteATCAircraft creates an enroute ATC aircraft along a flight plan.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) AICreateEnrouteATCAircraft(szContainerTitle string, szTailNumber string, iFlightNumber uint32, szFlightPlanPath string, dFlightPlanPosition float64, bTouchAndGo bool, RequestID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.AICreateEnrouteATCAircraft(szContainerTitle, szTailNumber, iFlightNumber, szFlightPlanPath, dFlightPlanPosition, bTouchAndGo, RequestID)
+}
+
+// AICreateNonATCAircraft creates a non-ATC aircraft at a specific position.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) AICreateNonATCAircraft(szContainerTitle string, szTailNumber string, initPos types.SIMCONNECT_DATA_INITPOSITION, RequestID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.AICreateNonATCAircraft(szContainerTitle, szTailNumber, initPos, RequestID)
+}
+
+// AICreateSimulatedObject creates a simulated object at a specific position.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) AICreateSimulatedObject(szContainerTitle string, initPos types.SIMCONNECT_DATA_INITPOSITION, RequestID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.AICreateSimulatedObject(szContainerTitle, initPos, RequestID)
+}
+
+// AIReleaseControl releases control of an AI object back to the simulator.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) AIReleaseControl(objectID uint32, requestID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.AIReleaseControl(objectID, requestID)
+}
+
+// AIRemoveObject removes an AI object from the simulation.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) AIRemoveObject(objectID uint32, requestID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.AIRemoveObject(objectID, requestID)
+}
+
+// EnumerateSimObjectsAndLiveries enumerates available sim objects and their liveries.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) EnumerateSimObjectsAndLiveries(requestID uint32, objectType types.SIMCONNECT_SIMOBJECT_TYPE) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.EnumerateSimObjectsAndLiveries(requestID, objectType)
+}
+
+// AICreateEnrouteATCAircraftEX1 creates an enroute ATC aircraft with livery selection.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) AICreateEnrouteATCAircraftEX1(szContainerTitle string, szLivery string, szTailNumber string, iFlightNumber uint32, szFlightPlanPath string, dFlightPlanPosition float64, bTouchAndGo bool, RequestID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.AICreateEnrouteATCAircraftEX1(szContainerTitle, szLivery, szTailNumber, iFlightNumber, szFlightPlanPath, dFlightPlanPosition, bTouchAndGo, RequestID)
+}
+
+// AICreateNonATCAircraftEX1 creates a non-ATC aircraft with livery selection.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) AICreateNonATCAircraftEX1(szContainerTitle string, szLivery string, szTailNumber string, initPos types.SIMCONNECT_DATA_INITPOSITION, RequestID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.AICreateNonATCAircraftEX1(szContainerTitle, szLivery, szTailNumber, initPos, RequestID)
+}
+
+// AICreateParkedATCAircraftEX1 creates a parked ATC aircraft with livery selection.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) AICreateParkedATCAircraftEX1(szContainerTitle string, szLivery string, szTailNumber string, szAirportID string, RequestID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.AICreateParkedATCAircraftEX1(szContainerTitle, szLivery, szTailNumber, szAirportID, RequestID)
+}

--- a/pkg/manager/events.go
+++ b/pkg/manager/events.go
@@ -1,0 +1,61 @@
+//go:build windows
+// +build windows
+
+package manager
+
+import "github.com/mrlm-net/simconnect/pkg/types"
+
+// MapClientEventToSimEvent maps a client event ID to a SimConnect event name.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) MapClientEventToSimEvent(eventID uint32, eventName string) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.MapClientEventToSimEvent(eventID, eventName)
+}
+
+// RemoveClientEvent removes a client event from a notification group.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) RemoveClientEvent(groupID uint32, eventID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.RemoveClientEvent(groupID, eventID)
+}
+
+// TransmitClientEvent transmits a client event to the simulator.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) TransmitClientEvent(objectID uint32, eventID uint32, data uint32, groupID uint32, flags types.SIMCONNECT_EVENT_FLAG) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.TransmitClientEvent(objectID, eventID, data, groupID, flags)
+}
+
+// TransmitClientEventEx1 transmits a client event with extended data to the simulator.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) TransmitClientEventEx1(objectID uint32, eventID uint32, groupID uint32, flags types.SIMCONNECT_EVENT_FLAG, data [5]uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.TransmitClientEventEx1(objectID, eventID, groupID, flags, data)
+}
+
+// MapClientDataNameToID maps a client data name to a client data ID.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) MapClientDataNameToID(clientDataName string, clientDataID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.MapClientDataNameToID(clientDataName, clientDataID)
+}

--- a/pkg/manager/facilities.go
+++ b/pkg/manager/facilities.go
@@ -1,0 +1,154 @@
+//go:build windows
+// +build windows
+
+package manager
+
+import (
+	"unsafe"
+
+	"github.com/mrlm-net/simconnect/pkg/datasets"
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+// RegisterFacilityDataset registers a complete facility dataset definition with SimConnect.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) RegisterFacilityDataset(definitionID uint32, dataset *datasets.FacilityDataSet) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.RegisterFacilityDataset(definitionID, dataset)
+}
+
+// AddToFacilityDefinition adds a field to a facility data definition.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) AddToFacilityDefinition(definitionID uint32, fieldName string) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.AddToFacilityDefinition(definitionID, fieldName)
+}
+
+// AddFacilityDataDefinitionFilter adds a filter to a facility data definition.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) AddFacilityDataDefinitionFilter(definitionID uint32, filterPath string, filterData unsafe.Pointer, filterDataSize uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.AddFacilityDataDefinitionFilter(definitionID, filterPath, filterData, filterDataSize)
+}
+
+// ClearAllFacilityDataDefinitionFilters clears all filters from a facility data definition.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) ClearAllFacilityDataDefinitionFilters(definitionID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.ClearAllFacilityDataDefinitionFilters(definitionID)
+}
+
+// RequestFacilitiesList requests a list of facilities of the specified type.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) RequestFacilitiesList(definitionID uint32, listType types.SIMCONNECT_FACILITY_LIST_TYPE) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.RequestFacilitiesList(definitionID, listType)
+}
+
+// RequestFacilitiesListEX1 requests a list of facilities of the specified type (extended version).
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) RequestFacilitiesListEX1(definitionID uint32, listType types.SIMCONNECT_FACILITY_LIST_TYPE) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.RequestFacilitiesListEX1(definitionID, listType)
+}
+
+// RequestFacilityData requests facility data for a specific ICAO code and region.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) RequestFacilityData(definitionID uint32, requestID uint32, icao string, region string) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.RequestFacilityData(definitionID, requestID, icao, region)
+}
+
+// RequestFacilityDataEX1 requests facility data with a facility type filter (extended version).
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) RequestFacilityDataEX1(definitionID uint32, requestID uint32, icao string, region string, facilityType byte) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.RequestFacilityDataEX1(definitionID, requestID, icao, region, facilityType)
+}
+
+// RequestJetwayData requests jetway data for an airport.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) RequestJetwayData(airportICAO string, arrayCount uint32, indexes *int32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.RequestJetwayData(airportICAO, arrayCount, indexes)
+}
+
+// SubscribeToFacilities subscribes to facility list updates of the specified type.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) SubscribeToFacilities(listType types.SIMCONNECT_FACILITY_LIST_TYPE, requestID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.SubscribeToFacilities(listType, requestID)
+}
+
+// SubscribeToFacilitiesEX1 subscribes to facility list updates with separate in-range and out-of-range request IDs.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) SubscribeToFacilitiesEX1(listType types.SIMCONNECT_FACILITY_LIST_TYPE, newElemInRangeRequestID uint32, oldElemOutRangeRequestID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.SubscribeToFacilitiesEX1(listType, newElemInRangeRequestID, oldElemOutRangeRequestID)
+}
+
+// UnsubscribeToFacilitiesEX1 unsubscribes from facility list updates.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) UnsubscribeToFacilitiesEX1(listType types.SIMCONNECT_FACILITY_LIST_TYPE, unsubscribeNewInRange bool, unsubscribeOldOutRange bool) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.UnsubscribeToFacilitiesEX1(listType, unsubscribeNewInRange, unsubscribeOldOutRange)
+}
+
+// RequestAllFacilities requests all facilities of the specified type.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) RequestAllFacilities(listType types.SIMCONNECT_FACILITY_LIST_TYPE, requestID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.RequestAllFacilities(listType, requestID)
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -246,6 +246,30 @@ type Manager interface {
 	// Returns ErrNotConnected if not connected to the simulator.
 	SetDataOnSimObject(definitionID uint32, objectID uint32, flags types.SIMCONNECT_DATA_SET_FLAG, arrayCount uint32, cbUnitSize uint32, data unsafe.Pointer) error
 
+	// Event Emission Methods
+	// These methods provide direct access to event operations without needing
+	// to call Client() first. They return ErrNotConnected if not connected.
+
+	// MapClientEventToSimEvent maps a client event ID to a SimConnect event name.
+	// Returns ErrNotConnected if not connected to the simulator.
+	MapClientEventToSimEvent(eventID uint32, eventName string) error
+
+	// RemoveClientEvent removes a client event from a notification group.
+	// Returns ErrNotConnected if not connected to the simulator.
+	RemoveClientEvent(groupID uint32, eventID uint32) error
+
+	// TransmitClientEvent transmits a client event to the simulator.
+	// Returns ErrNotConnected if not connected to the simulator.
+	TransmitClientEvent(objectID uint32, eventID uint32, data uint32, groupID uint32, flags types.SIMCONNECT_EVENT_FLAG) error
+
+	// TransmitClientEventEx1 transmits a client event with extended data to the simulator.
+	// Returns ErrNotConnected if not connected to the simulator.
+	TransmitClientEventEx1(objectID uint32, eventID uint32, groupID uint32, flags types.SIMCONNECT_EVENT_FLAG, data [5]uint32) error
+
+	// MapClientDataNameToID maps a client data name to a client data ID.
+	// Returns ErrNotConnected if not connected to the simulator.
+	MapClientDataNameToID(clientDataName string, clientDataID uint32) error
+
 	// Configuration getters
 
 	// IsAutoReconnect returns whether automatic reconnection is enabled

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -270,6 +270,148 @@ type Manager interface {
 	// Returns ErrNotConnected if not connected to the simulator.
 	MapClientDataNameToID(clientDataName string, clientDataID uint32) error
 
+	// Notification Group Methods
+	// These methods provide direct access to notification group operations without needing
+	// to call Client() first. They return ErrNotConnected if not connected.
+
+	// AddClientEventToNotificationGroup adds a client event to a notification group.
+	// Returns ErrNotConnected if not connected to the simulator.
+	AddClientEventToNotificationGroup(groupID uint32, eventID uint32, mask bool) error
+
+	// ClearNotificationGroup clears all events from a notification group.
+	// Returns ErrNotConnected if not connected to the simulator.
+	ClearNotificationGroup(groupID uint32) error
+
+	// RequestNotificationGroup requests a notification group.
+	// Returns ErrNotConnected if not connected to the simulator.
+	RequestNotificationGroup(groupID uint32, dwReserved uint32, flags uint32) error
+
+	// SetNotificationGroupPriority sets the priority of a notification group.
+	// Returns ErrNotConnected if not connected to the simulator.
+	SetNotificationGroupPriority(groupID uint32, priority uint32) error
+
+	// System State Methods
+	// These methods provide direct access to system state operations without needing
+	// to call Client() first. They return ErrNotConnected if not connected.
+
+	// RequestSystemState requests a system state value from the simulator.
+	// Returns ErrNotConnected if not connected to the simulator.
+	RequestSystemState(requestID uint32, state types.SIMCONNECT_SYSTEM_STATE) error
+
+	// SubscribeToSystemEvent subscribes to a SimConnect system event.
+	// WARNING: Do not use event IDs in the manager's reserved range (999,999,850 - 999,999,999).
+	// Use IDs from 1 to 999,999,849 for your own subscriptions.
+	// Returns ErrNotConnected if not connected to the simulator.
+	SubscribeToSystemEvent(eventID uint32, eventName string) error
+
+	// UnsubscribeFromSystemEvent unsubscribes from a SimConnect system event.
+	// Returns ErrNotConnected if not connected to the simulator.
+	UnsubscribeFromSystemEvent(eventID uint32) error
+
+	// Facility Methods
+	// These methods provide direct access to facility operations without needing
+	// to call Client() first. They return ErrNotConnected if not connected.
+
+	// RegisterFacilityDataset registers a complete facility dataset definition with SimConnect.
+	// Returns ErrNotConnected if not connected to the simulator.
+	RegisterFacilityDataset(definitionID uint32, dataset *datasets.FacilityDataSet) error
+
+	// AddToFacilityDefinition adds a field to a facility data definition.
+	// Returns ErrNotConnected if not connected to the simulator.
+	AddToFacilityDefinition(definitionID uint32, fieldName string) error
+
+	// AddFacilityDataDefinitionFilter adds a filter to a facility data definition.
+	// Returns ErrNotConnected if not connected to the simulator.
+	AddFacilityDataDefinitionFilter(definitionID uint32, filterPath string, filterData unsafe.Pointer, filterDataSize uint32) error
+
+	// ClearAllFacilityDataDefinitionFilters clears all filters from a facility data definition.
+	// Returns ErrNotConnected if not connected to the simulator.
+	ClearAllFacilityDataDefinitionFilters(definitionID uint32) error
+
+	// RequestFacilitiesList requests a list of facilities of the specified type.
+	// Returns ErrNotConnected if not connected to the simulator.
+	RequestFacilitiesList(definitionID uint32, listType types.SIMCONNECT_FACILITY_LIST_TYPE) error
+
+	// RequestFacilitiesListEX1 requests a list of facilities of the specified type (extended version).
+	// Returns ErrNotConnected if not connected to the simulator.
+	RequestFacilitiesListEX1(definitionID uint32, listType types.SIMCONNECT_FACILITY_LIST_TYPE) error
+
+	// RequestFacilityData requests facility data for a specific ICAO code and region.
+	// Returns ErrNotConnected if not connected to the simulator.
+	RequestFacilityData(definitionID uint32, requestID uint32, icao string, region string) error
+
+	// RequestFacilityDataEX1 requests facility data with a facility type filter (extended version).
+	// Returns ErrNotConnected if not connected to the simulator.
+	RequestFacilityDataEX1(definitionID uint32, requestID uint32, icao string, region string, facilityType byte) error
+
+	// RequestJetwayData requests jetway data for an airport.
+	// Returns ErrNotConnected if not connected to the simulator.
+	RequestJetwayData(airportICAO string, arrayCount uint32, indexes *int32) error
+
+	// SubscribeToFacilities subscribes to facility list updates of the specified type.
+	// Returns ErrNotConnected if not connected to the simulator.
+	SubscribeToFacilities(listType types.SIMCONNECT_FACILITY_LIST_TYPE, requestID uint32) error
+
+	// SubscribeToFacilitiesEX1 subscribes to facility list updates with separate in-range and out-of-range request IDs.
+	// Returns ErrNotConnected if not connected to the simulator.
+	SubscribeToFacilitiesEX1(listType types.SIMCONNECT_FACILITY_LIST_TYPE, newElemInRangeRequestID uint32, oldElemOutRangeRequestID uint32) error
+
+	// UnsubscribeToFacilitiesEX1 unsubscribes from facility list updates.
+	// Returns ErrNotConnected if not connected to the simulator.
+	UnsubscribeToFacilitiesEX1(listType types.SIMCONNECT_FACILITY_LIST_TYPE, unsubscribeNewInRange bool, unsubscribeOldOutRange bool) error
+
+	// RequestAllFacilities requests all facilities of the specified type.
+	// Returns ErrNotConnected if not connected to the simulator.
+	RequestAllFacilities(listType types.SIMCONNECT_FACILITY_LIST_TYPE, requestID uint32) error
+
+	// AI Traffic Methods
+	// These methods provide direct access to AI traffic operations without needing
+	// to call Client() first. They return ErrNotConnected if not connected.
+
+	// AICreateParkedATCAircraft creates a parked ATC aircraft at an airport.
+	// Returns ErrNotConnected if not connected to the simulator.
+	AICreateParkedATCAircraft(szContainerTitle string, szTailNumber string, szAirportID string, RequestID uint32) error
+
+	// AISetAircraftFlightPlan assigns a flight plan to an AI aircraft.
+	// Returns ErrNotConnected if not connected to the simulator.
+	AISetAircraftFlightPlan(objectID uint32, szFlightPlanPath string, requestID uint32) error
+
+	// AICreateEnrouteATCAircraft creates an enroute ATC aircraft along a flight plan.
+	// Returns ErrNotConnected if not connected to the simulator.
+	AICreateEnrouteATCAircraft(szContainerTitle string, szTailNumber string, iFlightNumber uint32, szFlightPlanPath string, dFlightPlanPosition float64, bTouchAndGo bool, RequestID uint32) error
+
+	// AICreateNonATCAircraft creates a non-ATC aircraft at a specific position.
+	// Returns ErrNotConnected if not connected to the simulator.
+	AICreateNonATCAircraft(szContainerTitle string, szTailNumber string, initPos types.SIMCONNECT_DATA_INITPOSITION, RequestID uint32) error
+
+	// AICreateSimulatedObject creates a simulated object at a specific position.
+	// Returns ErrNotConnected if not connected to the simulator.
+	AICreateSimulatedObject(szContainerTitle string, initPos types.SIMCONNECT_DATA_INITPOSITION, RequestID uint32) error
+
+	// AIReleaseControl releases control of an AI object back to the simulator.
+	// Returns ErrNotConnected if not connected to the simulator.
+	AIReleaseControl(objectID uint32, requestID uint32) error
+
+	// AIRemoveObject removes an AI object from the simulation.
+	// Returns ErrNotConnected if not connected to the simulator.
+	AIRemoveObject(objectID uint32, requestID uint32) error
+
+	// EnumerateSimObjectsAndLiveries enumerates available sim objects and their liveries.
+	// Returns ErrNotConnected if not connected to the simulator.
+	EnumerateSimObjectsAndLiveries(requestID uint32, objectType types.SIMCONNECT_SIMOBJECT_TYPE) error
+
+	// AICreateEnrouteATCAircraftEX1 creates an enroute ATC aircraft with livery selection.
+	// Returns ErrNotConnected if not connected to the simulator.
+	AICreateEnrouteATCAircraftEX1(szContainerTitle string, szLivery string, szTailNumber string, iFlightNumber uint32, szFlightPlanPath string, dFlightPlanPosition float64, bTouchAndGo bool, RequestID uint32) error
+
+	// AICreateNonATCAircraftEX1 creates a non-ATC aircraft with livery selection.
+	// Returns ErrNotConnected if not connected to the simulator.
+	AICreateNonATCAircraftEX1(szContainerTitle string, szLivery string, szTailNumber string, initPos types.SIMCONNECT_DATA_INITPOSITION, RequestID uint32) error
+
+	// AICreateParkedATCAircraftEX1 creates a parked ATC aircraft with livery selection.
+	// Returns ErrNotConnected if not connected to the simulator.
+	AICreateParkedATCAircraftEX1(szContainerTitle string, szLivery string, szTailNumber string, szAirportID string, RequestID uint32) error
+
 	// Configuration getters
 
 	// IsAutoReconnect returns whether automatic reconnection is enabled

--- a/pkg/manager/notifications.go
+++ b/pkg/manager/notifications.go
@@ -1,0 +1,48 @@
+//go:build windows
+// +build windows
+
+package manager
+
+// AddClientEventToNotificationGroup adds a client event to a notification group.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) AddClientEventToNotificationGroup(groupID uint32, eventID uint32, mask bool) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.AddClientEventToNotificationGroup(groupID, eventID, mask)
+}
+
+// ClearNotificationGroup clears all events from a notification group.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) ClearNotificationGroup(groupID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.ClearNotificationGroup(groupID)
+}
+
+// RequestNotificationGroup requests a notification group.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) RequestNotificationGroup(groupID uint32, dwReserved uint32, flags uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.RequestNotificationGroup(groupID, dwReserved, flags)
+}
+
+// SetNotificationGroupPriority sets the priority of a notification group.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) SetNotificationGroupPriority(groupID uint32, priority uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.SetNotificationGroupPriority(groupID, priority)
+}

--- a/pkg/manager/system.go
+++ b/pkg/manager/system.go
@@ -1,0 +1,45 @@
+//go:build windows
+// +build windows
+
+package manager
+
+import "github.com/mrlm-net/simconnect/pkg/types"
+
+// RequestSystemState requests a system state value from the simulator.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) RequestSystemState(requestID uint32, state types.SIMCONNECT_SYSTEM_STATE) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.RequestSystemState(requestID, state)
+}
+
+// SubscribeToSystemEvent subscribes to a SimConnect system event.
+//
+// WARNING: Do not use event IDs in the manager's reserved range (999,999,850 - 999,999,999).
+// The manager uses these IDs internally for its own system event subscriptions.
+// Use IDs from 1 to 999,999,849 for your own subscriptions.
+// See pkg/manager/ids.go for the full ID allocation reference.
+//
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) SubscribeToSystemEvent(eventID uint32, eventName string) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.SubscribeToSystemEvent(eventID, eventName)
+}
+
+// UnsubscribeFromSystemEvent unsubscribes from a SimConnect system event.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) UnsubscribeFromSystemEvent(eventID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.UnsubscribeFromSystemEvent(eventID)
+}


### PR DESCRIPTION
## Summary
- Add event emission delegation methods (#57): `MapClientEventToSimEvent`, `RemoveClientEvent`, `TransmitClientEvent`, `TransmitClientEventEx1`, `MapClientDataNameToID`
- Add notification group delegation methods (#58): `AddClientEventToNotificationGroup`, `ClearNotificationGroup`, `RequestNotificationGroup`, `SetNotificationGroupPriority`
- Add system state delegation methods (#60): `RequestSystemState`, `SubscribeToSystemEvent`, `UnsubscribeFromSystemEvent`
- Add facility operation delegation methods (#61): 13 methods covering facility definitions, requests, subscriptions, and jetway data
- Add AI traffic delegation methods (#62): 11 methods covering ATC/non-ATC aircraft creation, flight plans, and livery variants
- Update `Manager` interface with all 36 new method signatures

Closes #57
Closes #58
Closes #60
Closes #61
Closes #62

## Test plan
- [x] `go build ./...` passes
- [x] `go vet -unsafeptr=false ./...` passes
- [ ] All methods follow established delegation pattern (RLock + ErrNotConnected guard)
- [ ] Method signatures match engine.Client interface