### PR TITLE
fix(manager): align reserved ID range docs and remove dead code

### DIFF
--- a/pkg/manager/datasets.go
+++ b/pkg/manager/datasets.go
@@ -10,17 +10,6 @@ import (
 	"github.com/mrlm-net/simconnect/pkg/types"
 )
 
-// ensureConnected checks if the manager is connected and returns the client.
-// Returns ErrNotConnected if not connected.
-func (m *Instance) ensureConnected() error {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	if m.engine == nil {
-		return ErrNotConnected
-	}
-	return nil
-}
-
 // RegisterDataset registers a complete dataset definition with SimConnect.
 // This is a convenience method that iterates over all definitions in the dataset
 // and calls AddToDataDefinition for each one.

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -299,8 +299,8 @@ type Manager interface {
 	RequestSystemState(requestID uint32, state types.SIMCONNECT_SYSTEM_STATE) error
 
 	// SubscribeToSystemEvent subscribes to a SimConnect system event.
-	// WARNING: Do not use event IDs in the manager's reserved range (999,999,850 - 999,999,999).
-	// Use IDs from 1 to 999,999,849 for your own subscriptions.
+	// WARNING: Do not use event IDs in the manager's reserved range (999,999,900 - 999,999,999).
+	// Use IDs from 1 to 999,999,899 for your own subscriptions.
 	// Returns ErrNotConnected if not connected to the simulator.
 	SubscribeToSystemEvent(eventID uint32, eventName string) error
 

--- a/pkg/manager/system.go
+++ b/pkg/manager/system.go
@@ -18,9 +18,9 @@ func (m *Instance) RequestSystemState(requestID uint32, state types.SIMCONNECT_S
 
 // SubscribeToSystemEvent subscribes to a SimConnect system event.
 //
-// WARNING: Do not use event IDs in the manager's reserved range (999,999,850 - 999,999,999).
+// WARNING: Do not use event IDs in the manager's reserved range (999,999,900 - 999,999,999).
 // The manager uses these IDs internally for its own system event subscriptions.
-// Use IDs from 1 to 999,999,849 for your own subscriptions.
+// Use IDs from 1 to 999,999,899 for your own subscriptions.
 // See pkg/manager/ids.go for the full ID allocation reference.
 //
 // Returns ErrNotConnected if not connected to the simulator.


### PR DESCRIPTION
## Summary
- Fix doc comments on `SubscribeToSystemEvent` to match `ids.go` constants: reserved range is 999,999,900-999,999,999, user range is 1-999,999,899 (was incorrectly saying 850-999)
- Remove unused `ensureConnected()` helper from `datasets.go` (dead code with TOCTOU race)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet -unsafeptr=false ./...` passes