### PR TITLE
feat(website): accessibility hardening, SEO metadata, structured data, and crawler files

### DIFF
--- a/website/src/app.css
+++ b/website/src/app.css
@@ -7,8 +7,8 @@
 	--color-bg-tertiary: #1c2128;
 	--color-bg-code: #1a1e24;
 	--color-text-primary: #e6edf3;
-	--color-text-secondary: #8b949e;
-	--color-text-muted: #6e7681;
+	--color-text-secondary: #9198a1;
+	--color-text-muted: #848d97;
 	--color-link: #58a6ff;
 	--color-link-hover: #79c0ff;
 	--color-border: #30363d;
@@ -152,6 +152,10 @@ body {
 .prose .not-prose a:hover {
 	color: inherit;
 	text-decoration: none;
+}
+
+#main-content:focus {
+	outline: none;
 }
 
 .toc-aside {

--- a/website/src/app.html
+++ b/website/src/app.html
@@ -5,6 +5,7 @@
 		<link rel="icon" href="%sveltekit.assets%/plane-icon.png" type="image/png" />
 		<link rel="apple-touch-icon" href="%sveltekit.assets%/plane-icon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#0d1117" />
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />

--- a/website/src/lib/components/seo/JsonLd.svelte
+++ b/website/src/lib/components/seo/JsonLd.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	let { schema }: { schema: Record<string, unknown> } = $props();
+</script>
+
+<svelte:head>
+	{@html `<script type="application/ld+json">${JSON.stringify(schema)}</script>`}
+</svelte:head>

--- a/website/src/lib/components/seo/JsonLd.svelte
+++ b/website/src/lib/components/seo/JsonLd.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
 	let { schema }: { schema: Record<string, unknown> } = $props();
+
+	const safeJson = $derived(
+		JSON.stringify(schema)
+			.replace(/</g, '\\u003c')
+			.replace(/>/g, '\\u003e')
+			.replace(/&/g, '\\u0026')
+	);
 </script>
 
 <svelte:head>
-	{@html `<script type="application/ld+json">${JSON.stringify(schema)}</script>`}
+	{@html `<script type="application/ld+json">${safeJson}</script>`}
 </svelte:head>

--- a/website/src/lib/components/seo/SeoHead.svelte
+++ b/website/src/lib/components/seo/SeoHead.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import type { SiteConfig } from '$lib/types/index.js';
+
+	let {
+		siteConfig,
+		title,
+		description,
+		path = '',
+		type = 'website'
+	}: {
+		siteConfig: SiteConfig;
+		title: string;
+		description: string;
+		path?: string;
+		type?: string;
+	} = $props();
+
+	const pageTitle = $derived(
+		title.includes(siteConfig.title) ? title : `${title} - ${siteConfig.title}`
+	);
+	const canonicalUrl = $derived(`${siteConfig.url}${siteConfig.basePath}${path}`);
+	const ogImageUrl = $derived(`${siteConfig.url}${siteConfig.basePath}${siteConfig.ogImage}`);
+</script>
+
+<svelte:head>
+	<title>{pageTitle}</title>
+	<meta name="description" content={description} />
+	<link rel="canonical" href={canonicalUrl} />
+
+	<meta property="og:type" content={type} />
+	<meta property="og:title" content={pageTitle} />
+	<meta property="og:description" content={description} />
+	<meta property="og:url" content={canonicalUrl} />
+	<meta property="og:image" content={ogImageUrl} />
+	<meta property="og:image:width" content={String(siteConfig.ogImageWidth)} />
+	<meta property="og:image:height" content={String(siteConfig.ogImageHeight)} />
+	<meta property="og:locale" content={siteConfig.locale} />
+	<meta property="og:site_name" content={siteConfig.title} />
+
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content={pageTitle} />
+	<meta name="twitter:description" content={description} />
+	<meta name="twitter:image" content={ogImageUrl} />
+</svelte:head>

--- a/website/src/lib/config/site.ts
+++ b/website/src/lib/config/site.ts
@@ -4,5 +4,11 @@ export const siteConfig: SiteConfig = {
 	title: 'SimConnect Go SDK',
 	description: 'GoLang wrapper over SimConnect.dll for MSFS 2020/2024',
 	repoUrl: 'https://github.com/mrlm-net/simconnect',
-	basePath: ''
+	basePath: '',
+	url: 'https://simconnect.mrlm.net',
+	ogImage: '/hero.png',
+	ogImageWidth: 1057,
+	ogImageHeight: 639,
+	locale: 'en_US',
+	license: 'Apache-2.0'
 };

--- a/website/src/lib/types/index.ts
+++ b/website/src/lib/types/index.ts
@@ -22,6 +22,12 @@ export interface SiteConfig {
 	description: string;
 	repoUrl: string;
 	basePath: string;
+	url: string;
+	ogImage: string;
+	ogImageWidth: number;
+	ogImageHeight: number;
+	locale: string;
+	license: string;
 }
 
 export interface DocMeta {

--- a/website/src/routes/(docs)/+layout.svelte
+++ b/website/src/routes/(docs)/+layout.svelte
@@ -33,7 +33,7 @@
 />
 
 <div class="flex flex-1 pt-16 md:pl-70">
-	<main id="main-content" class="flex-1 min-w-0">
+	<main id="main-content" tabindex="-1" class="flex-1 min-w-0">
 		{@render children()}
 	</main>
 </div>

--- a/website/src/routes/(docs)/docs/+page.svelte
+++ b/website/src/routes/(docs)/docs/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { base } from '$app/paths';
+	import SeoHead from '$lib/components/seo/SeoHead.svelte';
+	import { siteConfig } from '$lib/config/site.js';
 	import type { DocMeta } from '$lib/types/index.js';
 
 	let { data }: { data: { docs: DocMeta[] } } = $props();
@@ -73,9 +75,12 @@
 	];
 </script>
 
-<svelte:head>
-	<title>Documentation - SimConnect Go SDK</title>
-</svelte:head>
+<SeoHead
+	{siteConfig}
+	title="Documentation - SimConnect Go SDK"
+	description="Browse all SimConnect Go SDK documentation guides"
+	path="/docs"
+/>
 
 <div class="flex">
 	<div class="min-w-0 flex-1 p-6 pl-8 lg:p-10 lg:pl-12">

--- a/website/src/routes/(docs)/docs/[slug]/+page.svelte
+++ b/website/src/routes/(docs)/docs/[slug]/+page.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { base } from '$app/paths';
 	import TableOfContents from '$lib/components/layout/TableOfContents.svelte';
+	import SeoHead from '$lib/components/seo/SeoHead.svelte';
+	import JsonLd from '$lib/components/seo/JsonLd.svelte';
+	import { siteConfig } from '$lib/config/site.js';
 	import type { DocPage } from '$lib/content/pipeline.js';
 
 	let {
@@ -14,10 +17,22 @@
 	} = $props();
 </script>
 
-<svelte:head>
-	<title>{data.doc.title} - SimConnect Go SDK</title>
-	<meta name="description" content={data.doc.description} />
-</svelte:head>
+<SeoHead
+	{siteConfig}
+	title="{data.doc.title} - SimConnect Go SDK"
+	description={data.doc.description}
+	path="/docs/{data.doc.slug}"
+	type="article"
+/>
+<JsonLd
+	schema={{
+		'@context': 'https://schema.org',
+		'@type': 'TechArticle',
+		headline: data.doc.title,
+		description: data.doc.description,
+		url: `${siteConfig.url}${siteConfig.basePath}/docs/${data.doc.slug}`
+	}}
+/>
 
 <div class="flex">
 	<article class="prose max-w-none min-w-0 flex-1 p-6 pl-8 lg:p-10 lg:pl-12">

--- a/website/src/routes/(docs)/examples/+page.svelte
+++ b/website/src/routes/(docs)/examples/+page.svelte
@@ -2,6 +2,8 @@
 	import Prism from 'prismjs';
 	import 'prismjs/components/prism-clike';
 	import 'prismjs/components/prism-go';
+	import SeoHead from '$lib/components/seo/SeoHead.svelte';
+	import { siteConfig } from '$lib/config/site.js';
 	import type { Example } from '$lib/content/examples.js';
 
 	let {
@@ -38,13 +40,12 @@
 	}
 </script>
 
-<svelte:head>
-	<title>Examples - SimConnect Go SDK</title>
-	<meta
-		name="description"
-		content="Browse example applications for the SimConnect Go SDK."
-	/>
-</svelte:head>
+<SeoHead
+	{siteConfig}
+	title="Examples - SimConnect Go SDK"
+	description="Browse example applications for the SimConnect Go SDK"
+	path="/examples"
+/>
 
 <div class="p-6 pl-8 lg:p-10 lg:pl-12">
 	<h1 class="mb-2 text-3xl font-bold" style="color: var(--color-text-primary);">Examples</h1>

--- a/website/src/routes/(docs)/getting-started/+page.svelte
+++ b/website/src/routes/(docs)/getting-started/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { base } from '$app/paths';
 	import TableOfContents from '$lib/components/layout/TableOfContents.svelte';
+	import SeoHead from '$lib/components/seo/SeoHead.svelte';
+	import { siteConfig } from '$lib/config/site.js';
 	import Prism from 'prismjs';
 	import 'prismjs/components/prism-clike';
 	import 'prismjs/components/prism-go';
@@ -120,13 +122,12 @@ func main() {
 	];
 </script>
 
-<svelte:head>
-	<title>Getting Started -- SimConnect Go SDK</title>
-	<meta
-		name="description"
-		content="Step-by-step guide to connect your Go application to Microsoft Flight Simulator."
-	/>
-</svelte:head>
+<SeoHead
+	{siteConfig}
+	title="Getting Started - SimConnect Go SDK"
+	description="Install, connect, and start building MSFS add-ons with Go"
+	path="/getting-started"
+/>
 
 <div class="flex">
 	<article class="prose max-w-none min-w-0 flex-1 p-6 pl-8 lg:p-10 lg:pl-12">

--- a/website/src/routes/(marketing)/+layout.svelte
+++ b/website/src/routes/(marketing)/+layout.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <Header siteConfig={data.siteConfig} onToggleSidebar={() => {}} showMenuButton={false} />
-<main id="main-content" class="flex-1 pt-16">
+<main id="main-content" tabindex="-1" class="flex-1 pt-16">
 	{@render children()}
 </main>
 <Footer siteConfig={data.siteConfig} />

--- a/website/src/routes/(marketing)/+page.svelte
+++ b/website/src/routes/(marketing)/+page.svelte
@@ -2,6 +2,9 @@
 	import { base } from '$app/paths';
 	import Prism from 'prismjs';
 	import 'prismjs/components/prism-go';
+	import SeoHead from '$lib/components/seo/SeoHead.svelte';
+	import JsonLd from '$lib/components/seo/JsonLd.svelte';
+	import { siteConfig } from '$lib/config/site.js';
 
 	let copied = $state(false);
 
@@ -140,13 +143,33 @@ func main() {
 	];
 </script>
 
-<svelte:head>
-	<title>SimConnect Go SDK -- GoLang wrapper for MSFS 2020/2024</title>
-	<meta
-		name="description"
-		content="Build Microsoft Flight Simulator add-ons with Go. Lightweight, typed, zero-dependency SimConnect wrapper."
-	/>
-</svelte:head>
+<SeoHead
+	{siteConfig}
+	title="SimConnect Go SDK -- GoLang wrapper for MSFS 2020/2024"
+	description="Build Microsoft Flight Simulator add-ons with Go. Lightweight, typed, zero-dependency SimConnect wrapper."
+	path="/"
+/>
+<JsonLd
+	schema={{
+		'@context': 'https://schema.org',
+		'@type': 'WebSite',
+		name: siteConfig.title,
+		url: `${siteConfig.url}${siteConfig.basePath}/`,
+		description: siteConfig.description
+	}}
+/>
+<JsonLd
+	schema={{
+		'@context': 'https://schema.org',
+		'@type': 'SoftwareSourceCode',
+		name: siteConfig.title,
+		description: siteConfig.description,
+		codeRepository: siteConfig.repoUrl,
+		programmingLanguage: 'Go',
+		runtimePlatform: 'Windows',
+		license: `https://opensource.org/licenses/${siteConfig.license}`
+	}}
+/>
 
 <!-- Hero -->
 <section class="relative overflow-hidden py-24 md:py-36">

--- a/website/src/routes/(marketing)/+page.svelte
+++ b/website/src/routes/(marketing)/+page.svelte
@@ -145,7 +145,7 @@ func main() {
 
 <SeoHead
 	{siteConfig}
-	title="SimConnect Go SDK -- GoLang wrapper for MSFS 2020/2024"
+	title="SimConnect Go SDK — GoLang wrapper for MSFS 2020/2024"
 	description="Build Microsoft Flight Simulator add-ons with Go. Lightweight, typed, zero-dependency SimConnect wrapper."
 	path="/"
 />

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
 	import '../app.css';
+	import { afterNavigate } from '$app/navigation';
 	import type { Snippet } from 'svelte';
 
 	let { children }: { children: Snippet } = $props();
+
+	afterNavigate(() => {
+		const main = document.getElementById('main-content');
+		if (main) {
+			main.focus({ preventScroll: true });
+		}
+	});
 </script>
 
 <div class="min-h-screen flex flex-col">

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -5,7 +5,12 @@
 
 	let { children }: { children: Snippet } = $props();
 
+	let isFirstNav = true;
 	afterNavigate(() => {
+		if (isFirstNav) {
+			isFirstNav = false;
+			return;
+		}
 		const main = document.getElementById('main-content');
 		if (main) {
 			main.focus({ preventScroll: true });

--- a/website/src/routes/llm.txt/+server.ts
+++ b/website/src/routes/llm.txt/+server.ts
@@ -1,0 +1,37 @@
+import type { RequestHandler } from './$types.js';
+import { loadDocIndex } from '$lib/content/pipeline.js';
+import { siteConfig } from '$lib/config/site.js';
+
+export const prerender = true;
+
+export const GET: RequestHandler = () => {
+	const baseUrl = `${siteConfig.url}${siteConfig.basePath}`;
+	const docs = loadDocIndex();
+	docs.sort((a, b) => a.order - b.order);
+
+	const docList = docs.map((doc) => `- [${doc.title}](${baseUrl}/docs/${doc.slug}): ${doc.description}`).join('\n');
+
+	const content = `# ${siteConfig.title}
+
+> ${siteConfig.description}
+
+## Key URLs
+
+- Website: ${baseUrl}/
+- Getting Started: ${baseUrl}/getting-started
+- Documentation: ${baseUrl}/docs
+- Examples: ${baseUrl}/examples
+- Repository: ${siteConfig.repoUrl}
+- Go Reference: https://pkg.go.dev/github.com/mrlm-net/simconnect
+
+## Documentation
+
+${docList}
+`;
+
+	return new Response(content, {
+		headers: {
+			'Content-Type': 'text/plain; charset=utf-8'
+		}
+	});
+};

--- a/website/src/routes/sitemap.xml/+server.ts
+++ b/website/src/routes/sitemap.xml/+server.ts
@@ -6,7 +6,6 @@ export const prerender = true;
 
 export const GET: RequestHandler = () => {
 	const baseUrl = `${siteConfig.url}${siteConfig.basePath}`;
-	const today = new Date().toISOString().split('T')[0];
 
 	const staticPages = ['/', '/getting-started', '/docs', '/examples'];
 
@@ -19,7 +18,6 @@ export const GET: RequestHandler = () => {
 		.map(
 			(page) => `  <url>
     <loc>${baseUrl}${page}</loc>
-    <lastmod>${today}</lastmod>
   </url>`
 		)
 		.join('\n');

--- a/website/src/routes/sitemap.xml/+server.ts
+++ b/website/src/routes/sitemap.xml/+server.ts
@@ -1,0 +1,37 @@
+import type { RequestHandler } from './$types.js';
+import { loadDocIndex } from '$lib/content/pipeline.js';
+import { siteConfig } from '$lib/config/site.js';
+
+export const prerender = true;
+
+export const GET: RequestHandler = () => {
+	const baseUrl = `${siteConfig.url}${siteConfig.basePath}`;
+	const today = new Date().toISOString().split('T')[0];
+
+	const staticPages = ['/', '/getting-started', '/docs', '/examples'];
+
+	const docs = loadDocIndex();
+	const docPages = docs.map((doc) => `/docs/${doc.slug}`);
+
+	const allPages = [...staticPages, ...docPages];
+
+	const urlEntries = allPages
+		.map(
+			(page) => `  <url>
+    <loc>${baseUrl}${page}</loc>
+    <lastmod>${today}</lastmod>
+  </url>`
+		)
+		.join('\n');
+
+	const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urlEntries}
+</urlset>`;
+
+	return new Response(xml, {
+		headers: {
+			'Content-Type': 'application/xml'
+		}
+	});
+};

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://simconnect.mrlm.net/sitemap.xml


### PR DESCRIPTION
## Summary

- Extended `SiteConfig` interface with `url`, `ogImage`, `ogImageWidth`, `ogImageHeight`, `locale`, and `license` fields
- Created reusable `SeoHead` component (Open Graph, Twitter Card, canonical URL) and `JsonLd` component (schema.org structured data)
- Replaced all inline `<svelte:head>` blocks across 5 pages with `SeoHead`/`JsonLd` components
- Added `robots.txt` (static), prerendered `sitemap.xml` endpoint, and prerendered `llm.txt` endpoint for crawler/LLM discovery
- Accessibility improvements: `theme-color` meta tag, `afterNavigate` focus management for screen readers, `tabindex="-1"` on main elements, improved color contrast ratios for `text-secondary` (#9198a1) and `text-muted` (#848d97)

Closes #93

## Test plan

- [x] `npm run build` succeeds with zero errors
- [x] `build/robots.txt`, `build/sitemap.xml`, and `build/llm.txt` present in output
- [x] `index.html` contains og:title, og:image, twitter:card, canonical, and JSON-LD script tags
- [ ] Visual regression: verify landing page, docs, getting-started, examples render unchanged (colors slightly warmer)
- [ ] Accessibility audit: verify skip-to-content link works, focus management on navigation, no outline flash on main