### PR TITLE
feat(website): add pulse animation to code preview dots

### DIFF
--- a/website/src/routes/(marketing)/+page.svelte
+++ b/website/src/routes/(marketing)/+page.svelte
@@ -334,7 +334,7 @@ func main() {
 					class="flex items-center gap-2 border-b px-4 py-2.5"
 					style="background-color: var(--color-bg-tertiary); border-color: var(--color-border);"
 				>
-					<span class="inline-block h-2.5 w-2.5 rounded-full" style="background-color: var(--color-link); opacity: 0.6;"></span>
+					<span class="dot-pulse inline-block h-2.5 w-2.5 rounded-full" style="background-color: var(--color-link);"></span>
 					<span class="font-mono text-xs" style="color: var(--color-text-muted);">Low-Level Client</span>
 				</div>
 				<pre class="overflow-x-auto p-4"><code class="language-go text-[0.8125rem] leading-relaxed">{@html clientHighlighted}</code></pre>
@@ -348,7 +348,7 @@ func main() {
 					class="flex items-center gap-2 border-b px-4 py-2.5"
 					style="background-color: var(--color-bg-tertiary); border-color: var(--color-border);"
 				>
-					<span class="inline-block h-2.5 w-2.5 rounded-full" style="background-color: #3fb950; opacity: 0.6;"></span>
+					<span class="dot-pulse inline-block h-2.5 w-2.5 rounded-full" style="background-color: #3fb950;"></span>
 					<span class="font-mono text-xs" style="color: var(--color-text-muted);">Manager with Auto-Reconnect</span>
 				</div>
 				<pre class="overflow-x-auto p-4"><code class="language-go text-[0.8125rem] leading-relaxed">{@html managerHighlighted}</code></pre>
@@ -399,5 +399,25 @@ func main() {
 <style>
 	a.group:hover {
 		border-color: var(--color-link) !important;
+	}
+
+	@keyframes dot-pulse {
+		0%, 100% {
+			opacity: 0.4;
+		}
+		50% {
+			opacity: 1;
+		}
+	}
+
+	.dot-pulse {
+		animation: dot-pulse 3s ease-in-out infinite;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.dot-pulse {
+			animation: none;
+			opacity: 0.7;
+		}
 	}
 </style>


### PR DESCRIPTION
## Summary
- Add subtle CSS pulse animation to the two colored dots in the "Two ways to connect" code preview section on the homepage
- Dots oscillate opacity 0.4 → 1.0 on a 3s ease-in-out infinite loop
- Respects `prefers-reduced-motion: reduce` (static opacity 0.7)

Closes #96

## Test plan
- [ ] Verify both dots (blue + green) pulse smoothly on homepage
- [ ] Verify `prefers-reduced-motion: reduce` disables animation
- [ ] Verify no other elements on the page are affected
- [ ] Verify build passes