### PR TITLE
fix(website): add copy feedback interaction to examples page

### DIFF
--- a/website/src/routes/(docs)/examples/+page.svelte
+++ b/website/src/routes/(docs)/examples/+page.svelte
@@ -14,6 +14,7 @@
 
 	let activeCategory = $state('all');
 	let expandedSlug = $state('');
+	let copiedSlug = $state('');
 
 	const categories = $derived.by(() => {
 		const cats = new Set(data.examples.map((e) => e.category));
@@ -35,8 +36,10 @@
 		expandedSlug = expandedSlug === slug ? '' : slug;
 	}
 
-	function copyCode(code: string) {
+	function copyCode(slug: string, code: string) {
 		navigator.clipboard.writeText(code);
+		copiedSlug = slug;
+		setTimeout(() => (copiedSlug = ''), 2000);
 	}
 </script>
 
@@ -124,11 +127,18 @@
 					<div class="border-t px-4 pb-4" style="border-color: var(--color-border);">
 						<div class="relative mt-3">
 							<button
-								class="absolute top-2 right-2 rounded px-2 py-1 text-xs transition-colors"
-								style="background-color: var(--color-bg-tertiary); color: var(--color-text-muted);"
-								onclick={() => copyCode(example.code)}
+								class="absolute top-2 right-2 flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors"
+								style="background-color: var(--color-bg-tertiary); color: {copiedSlug === example.slug ? '#3fb950' : 'var(--color-text-muted)'};"
+								aria-label="Copy code"
+								onclick={() => copyCode(example.slug, example.code)}
 							>
-								Copy
+								{#if copiedSlug === example.slug}
+									<svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
+									Copied
+								{:else}
+									<svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+									Copy
+								{/if}
 							</button>
 							<pre
 								class="overflow-x-auto rounded-lg border p-4"


### PR DESCRIPTION
## Summary
- Add visual feedback to the copy button on example code blocks (examples page)
- Matches homepage install command behavior: clipboard icon → checkmark, text "Copy" → "Copied", green color, 2s timeout
- Added `aria-label` for accessibility

## Test plan
- [ ] Click "Copy" on any example — verify icon changes to checkmark, text to "Copied", color to green
- [ ] After 2s, verify it reverts back to clipboard icon and "Copy" text
- [ ] Verify only the clicked example shows feedback (not all of them)
- [ ] Build passes