### PR TITLE
fix(examples): add description comment to simconnect-events

### DIFF
--- a/examples/simconnect-events/main.go
+++ b/examples/simconnect-events/main.go
@@ -1,3 +1,4 @@
+// Demonstrates all manager event handlers and channel subscriptions.
 package main
 
 import (


### PR DESCRIPTION
## Summary
- Add proper description comment to `simconnect-events/main.go`
- The `extractDescription()` function was picking up the Unicode separator line (`──────`) as the description, rendering as a horizontal rule on the examples page

## Test plan
- [ ] Verify simconnect-events shows "Demonstrates all manager event handlers and channel subscriptions." on examples page
- [ ] Build passes