### PR TITLE
feat(website): changelog, CTA section, badge fixes, doc corrections

### DIFF
--- a/docs/config-manager.md
+++ b/docs/config-manager.md
@@ -349,7 +349,7 @@ func main() {
         manager.WithHeartbeat(engine.HEARTBEAT_6HZ),
     )
 
-    mgr.OnStateChange(func(old, new manager.ConnectionState) {
+    mgr.OnConnectionStateChange(func(old, new manager.ConnectionState) {
         logger.Info("State changed", "from", old, "to", new)
     })
 

--- a/docs/manager-requests-ids.md
+++ b/docs/manager-requests-ids.md
@@ -19,7 +19,8 @@ The manager uses a **high-number ID reservation strategy** to maximize flexibili
 |-------|-------|-------|---------|
 | 1 - 999,999,849 | **User Applications** | 999,999,849 | User-defined data definitions and requests |
 | 999,999,850 - 999,999,886 | **Manager** | 37 | Custom system event IDs (dynamic allocation) |
-| 999,999,887 - 999,999,999 | **Manager** | 113 | Internal manager operations (reserved) |
+| 999,999,887 - 999,999,899 | **Reserved** | 13 | Unallocated buffer for future use |
+| 999,999,900 - 999,999,999 | **Manager** | 100 | Internal manager operations (reserved) |
 
 ### Why High Numbers for Manager?
 
@@ -33,8 +34,8 @@ The manager uses a **high-number ID reservation strategy** to maximize flexibili
 ### Simulator State System
 
 ```go
-SimulatorDefinitionID = 999999900  // Simulator state data definition
-SimulatorRequestID    = 999999901  // Periodic simulator state requests
+CameraDefinitionID = 999999900  // Camera/simulator state data definition
+CameraRequestID    = 999999901  // Periodic camera state data polling
 ```
 
 **Purpose**: Continuously polls simulator state (camera, simulation, environment, aircraft telemetry) to update the manager's `SimState`.
@@ -70,18 +71,18 @@ The manager's simulator state data definition now includes additional environmen
 The manager reserves specific high-number IDs for internal system event subscriptions. These are registered on connection open and used for request tracking; the actual SimConnect system event names are standard (e.g. "Pause", "Sim", "FlightLoaded").
 
 ```go
-PauseEventID                 = 999999999 // Pause/unpause event subscription
-SimEventID                   = 999999998 // Sim start/stop event subscription
-FlightLoadedEventID          = 999999997 // Flight file loaded (filename returned)
-AircraftLoadedEventID        = 999999996 // Aircraft file loaded/changed (.AIR)
-ObjectAddedEventID           = 999999995 // AI object added
-ObjectRemovedEventID         = 999999994 // AI object removed
-FlightPlanActivatedEventID   = 999999993 // Flight plan activated (filename returned)
-FlightPlanDeactivatedEventID = 999999992 // Flight plan deactivated
+PauseEventID                 = 999999998 // Pause/unpause event subscription
+SimEventID                   = 999999997 // Sim start/stop event subscription
+FlightLoadedEventID          = 999999996 // Flight file loaded (filename returned)
+AircraftLoadedEventID        = 999999995 // Aircraft file loaded/changed (.AIR)
+ObjectAddedEventID           = 999999994 // AI object added
+ObjectRemovedEventID         = 999999993 // AI object removed
+FlightPlanActivatedEventID   = 999999992 // Flight plan activated (filename returned)
 CrashedEventID               = 999999991 // Simulator crashed (manager reserved ID)
 CrashResetEventID            = 999999990 // Crash reset event (manager reserved ID)
 SoundEventID                 = 999999989 // Sound event (manager reserved ID)
 ViewEventID                  = 999999988 // View camera event (manager reserved ID)
+FlightPlanDeactivatedEventID = 999999987 // Flight plan deactivated
 ```
 
 **Purpose**: These IDs are used to register and track the manager's internal subscriptions to SimConnect system events. Responses may arrive as different `SIMCONNECT_RECV` variants (e.g., `SIMCONNECT_RECV_EVENT`, `SIMCONNECT_RECV_EVENT_FILENAME`, `SIMCONNECT_RECV_EVENT_OBJECT_ADDREMOVE`).

--- a/docs/usage-manager.md
+++ b/docs/usage-manager.md
@@ -238,10 +238,10 @@ Creates a subscription filtered by message types.
 
 ```go
 // Only receive object data and event messages
-sub := mgr.SubscribeWithType("game-events", 10,
+sub := mgr.SubscribeWithType("game-events", 10, []types.SIMCONNECT_RECV_ID{
     types.SIMCONNECT_RECV_ID_SIMOBJECT_DATA,
     types.SIMCONNECT_RECV_ID_EVENT,
-)
+})
 defer sub.Unsubscribe()
 ```
 

--- a/website/src/lib/components/layout/Header.svelte
+++ b/website/src/lib/components/layout/Header.svelte
@@ -53,8 +53,7 @@
 		href={siteConfig.repoUrl}
 		target="_blank"
 		rel="noopener noreferrer"
-		class="rounded p-1.5 transition-colors"
-		style="color: var(--color-text-secondary);"
+		class="github-link rounded p-1.5 transition-colors"
 		aria-label="View on GitHub"
 	>
 		<svg
@@ -70,3 +69,12 @@
 		</svg>
 	</a>
 </header>
+
+<style>
+	.github-link {
+		color: var(--color-text-secondary);
+	}
+	.github-link:hover {
+		color: #fff;
+	}
+</style>

--- a/website/src/lib/types/index.ts
+++ b/website/src/lib/types/index.ts
@@ -37,3 +37,13 @@ export interface DocMeta {
 	order: number;
 	section: string;
 }
+
+export interface ChangelogRelease {
+	tag: string;
+	name: string;
+	date: string;
+	body: string;
+	renderedBody: string;
+	url: string;
+	prerelease: boolean;
+}

--- a/website/src/routes/(docs)/changelog/+page.server.ts
+++ b/website/src/routes/(docs)/changelog/+page.server.ts
@@ -1,0 +1,108 @@
+import type { PageServerLoad } from './$types.js';
+import type { ChangelogRelease } from '$lib/types/index.js';
+import { compile } from 'mdsvex';
+import Prism from 'prismjs';
+import 'prismjs/components/prism-go.js';
+import 'prismjs/components/prism-bash.js';
+import 'prismjs/components/prism-json.js';
+import 'prismjs/components/prism-yaml.js';
+import 'prismjs/components/prism-typescript.js';
+import rehypeSlug from '$lib/plugins/rehype-slug.js';
+import rehypeRewriteLinks from '$lib/plugins/rehype-rewrite-links.js';
+import rehypeTableWrap from '$lib/plugins/rehype-table-wrap.js';
+
+export const prerender = true;
+
+interface GitHubRelease {
+	tag_name: string;
+	name: string;
+	published_at: string;
+	body: string;
+	html_url: string;
+	prerelease: boolean;
+	draft: boolean;
+}
+
+function escapeHtml(text: string): string {
+	return text
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;');
+}
+
+function highlightCode(code: string, lang: string | undefined): string {
+	if (lang && Prism.languages[lang]) {
+		const html = Prism.highlight(code, Prism.languages[lang], lang);
+		return `<pre class="language-${lang}"><code class="language-${lang}">${html}</code></pre>`;
+	}
+	return `<pre><code>${escapeHtml(code)}</code></pre>`;
+}
+
+/**
+ * Resolve mdsvex {@html `...`} directives by extracting their template literal content.
+ */
+function resolveHtmlDirectives(code: string): string {
+	return code.replace(/\{@html `([\s\S]*?)`\}/g, (_match, content) => {
+		return content.replace(/\\`/g, '`');
+	});
+}
+
+async function renderMarkdown(markdown: string): Promise<string> {
+	if (!markdown.trim()) return '';
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const compiled = await compile(markdown, {
+		highlight: { highlighter: highlightCode },
+		rehypePlugins: [rehypeSlug, rehypeRewriteLinks, rehypeTableWrap]
+	} as any);
+
+	if (!compiled) return '';
+
+	let code = compiled.code;
+	code = code
+		.replace(/<script[\s\S]*?<\/script>/gi, '')
+		.replace(/<style[\s\S]*?<\/style>/gi, '');
+
+	return resolveHtmlDirectives(code).trim();
+}
+
+export const load: PageServerLoad = async ({ fetch }) => {
+	try {
+		const response = await fetch(
+			'https://api.github.com/repos/mrlm-net/simconnect/releases?per_page=100',
+			{
+				headers: {
+					Accept: 'application/vnd.github.v3+json',
+					'User-Agent': 'simconnect-docs'
+				}
+			}
+		);
+
+		if (!response.ok) {
+			return { releases: [] };
+		}
+
+		const data: GitHubRelease[] = await response.json();
+
+		const filtered = data.filter((r) => !r.draft);
+		filtered.sort(
+			(a, b) => new Date(b.published_at).getTime() - new Date(a.published_at).getTime()
+		);
+
+		const releases: ChangelogRelease[] = await Promise.all(
+			filtered.map(async (r) => ({
+				tag: r.tag_name,
+				name: r.name || r.tag_name,
+				date: r.published_at,
+				body: r.body || '',
+				renderedBody: await renderMarkdown(r.body || ''),
+				url: r.html_url,
+				prerelease: r.prerelease
+			}))
+		);
+
+		return { releases };
+	} catch {
+		return { releases: [] };
+	}
+};

--- a/website/src/routes/(docs)/changelog/+page.svelte
+++ b/website/src/routes/(docs)/changelog/+page.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+	import SeoHead from '$lib/components/seo/SeoHead.svelte';
+	import JsonLd from '$lib/components/seo/JsonLd.svelte';
+	import { siteConfig } from '$lib/config/site.js';
+	import type { ChangelogRelease } from '$lib/types/index.js';
+
+	let {
+		data
+	}: {
+		data: { releases: ChangelogRelease[] };
+	} = $props();
+
+	function formatDate(iso: string): string {
+		const d = new Date(iso);
+		return d.toLocaleDateString('en-US', {
+			year: 'numeric',
+			month: 'long',
+			day: 'numeric'
+		});
+	}
+</script>
+
+<SeoHead
+	{siteConfig}
+	title="Changelog - SimConnect Go SDK"
+	description="Release history for the SimConnect Go SDK."
+	path="/changelog"
+/>
+<JsonLd
+	schema={{
+		'@context': 'https://schema.org',
+		'@type': 'WebPage',
+		name: 'Changelog',
+		description: 'Release history for the SimConnect Go SDK.',
+		url: `${siteConfig.url}${siteConfig.basePath}/changelog`
+	}}
+/>
+
+<div class="p-6 pl-8 lg:p-10 lg:pl-12">
+	<h1 class="mb-2 text-3xl font-bold" style="color: var(--color-text-primary);">Changelog</h1>
+	<p class="mb-8" style="color: var(--color-text-secondary);">
+		Release history for the SimConnect Go SDK.
+	</p>
+
+	{#if data.releases.length === 0}
+		<div
+			class="rounded-lg border p-8 text-center"
+			style="border-color: var(--color-border); background-color: var(--color-bg-secondary);"
+		>
+			<p class="mb-2" style="color: var(--color-text-secondary);">
+				No releases found.
+			</p>
+			<a
+				href="{siteConfig.repoUrl}/releases"
+				target="_blank"
+				rel="noopener noreferrer"
+				class="text-sm"
+				style="color: var(--color-link);"
+			>
+				View releases on GitHub &nearr;
+			</a>
+		</div>
+	{:else}
+		<div class="space-y-0">
+			{#each data.releases as release, i (release.tag)}
+				{#if i > 0}
+					<hr
+						class="my-8"
+						style="border-color: var(--color-border);"
+					/>
+				{/if}
+				<article>
+					<div class="mb-4 flex flex-wrap items-center gap-3">
+						<a
+							href={release.url}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="text-xl font-semibold transition-colors"
+							style="color: var(--color-link);"
+						>
+							{release.tag}
+						</a>
+						{#if release.name !== release.tag}
+							<span
+								class="text-lg font-medium"
+								style="color: var(--color-text-primary);"
+							>
+								&mdash; {release.name}
+							</span>
+						{/if}
+						{#if release.prerelease}
+							<span
+								class="rounded-full px-2 py-0.5 text-xs font-medium"
+								style="background-color: rgba(210, 153, 34, 0.15); color: #d2992a;"
+							>
+								pre-release
+							</span>
+						{/if}
+					</div>
+					<time
+						class="mb-4 block text-sm"
+						datetime={release.date}
+						style="color: var(--color-text-muted);"
+					>
+						{formatDate(release.date)}
+					</time>
+					{#if release.renderedBody}
+						<div class="prose max-w-none">
+							{@html release.renderedBody}
+						</div>
+					{/if}
+				</article>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/website/src/routes/(marketing)/+page.svelte
+++ b/website/src/routes/(marketing)/+page.svelte
@@ -231,11 +231,30 @@ func main() {
 			</a>
 			{#if data.milestone}
 				<a href="https://github.com/mrlm-net/simconnect/milestone/{data.milestone.number}" target="_blank" rel="noopener noreferrer" class="badge">
-					<span class="badge-label">upcoming</span><span class="badge-value">{data.milestone.title} — {data.milestone.progress}%</span>
+					<span class="badge-label">upcoming</span><span class="badge-value">{data.milestone.title}</span>
 				</a>
 			{/if}
 		</div>
 	</div>
+</section>
+
+<!-- CTA Banner -->
+<section class="relative isolate -mt-6" aria-labelledby="cta-heading">
+	<div class="px-6 py-16 sm:py-20 lg:px-8">
+		<div class="mx-auto max-w-2xl text-center">
+			<h2 id="cta-heading" class="text-4xl font-semibold tracking-tight text-balance sm:text-5xl" style="color: var(--color-text-primary);">Build powerful MSFS&nbsp;add&#8209;ons with&nbsp;Go.</h2>
+			<p class="mx-auto mt-6 max-w-xl text-lg/8 text-pretty" style="color: var(--color-text-secondary);">From real&#8209;time telemetry dashboards to&nbsp;AI&nbsp;traffic controllers&nbsp;&mdash; connect directly to&nbsp;the simulator with a&nbsp;typed, zero&#8209;dependency&nbsp;SDK.</p>
+		</div>
+	</div>
+	<svg viewBox="0 0 1024 1024" aria-hidden="true" class="absolute top-1/2 left-1/2 -z-10 size-256 -translate-x-1/2 mask-[radial-gradient(closest-side,white,transparent)]">
+		<circle r="512" cx="512" cy="512" fill="url(#cta-gradient)" fill-opacity="0.08" />
+		<defs>
+			<radialGradient id="cta-gradient">
+				<stop stop-color="#58a6ff" />
+				<stop offset="1" stop-color="#a5d6ff" />
+			</radialGradient>
+		</defs>
+	</svg>
 </section>
 
 <!-- Features -->
@@ -374,7 +393,7 @@ func main() {
 	.badge-value {
 		padding: 0.25rem 0.4rem;
 		background-color: var(--color-link);
-		color: var(--color-bg-primary);
+		color: #fff;
 	}
 
 	.badge-go {

--- a/website/src/routes/+layout.server.ts
+++ b/website/src/routes/+layout.server.ts
@@ -11,7 +11,8 @@ export const load: LayoutServerLoad = () => {
 	const navigation = buildNavigation(docs, base);
 	const topLinks = [
 		{ title: 'Getting Started', href: `${base}/getting-started`, order: 0 },
-		{ title: 'Examples', href: `${base}/examples`, order: 1 }
+		{ title: 'Examples', href: `${base}/examples`, order: 1 },
+		{ title: 'Changelog', href: `${base}/changelog`, order: 2 }
 	];
 
 	return {

--- a/website/src/routes/llm.txt/+server.ts
+++ b/website/src/routes/llm.txt/+server.ts
@@ -21,6 +21,7 @@ export const GET: RequestHandler = () => {
 - Getting Started: ${baseUrl}/getting-started
 - Documentation: ${baseUrl}/docs
 - Examples: ${baseUrl}/examples
+- Changelog: ${baseUrl}/changelog
 - Repository: ${siteConfig.repoUrl}
 - Go Reference: https://pkg.go.dev/github.com/mrlm-net/simconnect
 

--- a/website/src/routes/sitemap.xml/+server.ts
+++ b/website/src/routes/sitemap.xml/+server.ts
@@ -34,7 +34,8 @@ export const GET: RequestHandler = () => {
 		{ path: '/', priority: '1.0', lastmod: buildDate },
 		{ path: '/getting-started', priority: '0.9', lastmod: buildDate },
 		{ path: '/docs', priority: '0.8', lastmod: buildDate },
-		{ path: '/examples', priority: '0.8', lastmod: buildDate }
+		{ path: '/examples', priority: '0.8', lastmod: buildDate },
+		{ path: '/changelog', priority: '0.7', lastmod: buildDate }
 	];
 
 	const docs = loadDocIndex();


### PR DESCRIPTION
## Summary
- **Changelog page** (#105): Build-time page fetching GitHub Releases API, rendered with mdsvex + Prism highlighting
- **CTA section** (#106): Banner below hero with SimConnect value proposition, consistent design tokens
- **Badge fixes** (#107): Removed milestone percentage from upcoming badge, white text on badge values, GitHub icon hover fix
- **Doc corrections** (#104): Fixed `OnConnectionStateChange` method name, `SubscribeWithType` signature, all 12 manager event ID values and range table

## Test plan
- [ ] Verify changelog page renders at `/changelog` with release entries
- [ ] Verify CTA section appears below hero on landing page with correct styling
- [ ] Verify badge values show white text, upcoming badge shows only version number
- [ ] Verify GitHub icon in header turns white on hover
- [ ] Verify docs corrections match source code in `pkg/manager/`
- [ ] Build passes: `cd website && npm run build`

Closes #104, Closes #105, Closes #106, Closes #107