### PR TITLE
feat(examples): add event emit and listen commands to simvar-cli

### DIFF
--- a/examples/simvar-cli/emit.go
+++ b/examples/simvar-cli/emit.go
@@ -1,0 +1,173 @@
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/mrlm-net/cure/pkg/terminal"
+	"github.com/mrlm-net/simconnect/pkg/engine"
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+type emitCommand struct {
+	engineOpts []engine.Option
+	timeout    int
+}
+
+func (c *emitCommand) Name() string        { return "emit" }
+func (c *emitCommand) Description() string { return "Fire a client event in the simulator" }
+func (c *emitCommand) Usage() string {
+	return "emit <event-name> [data...]\n\nExamples:\n  emit AP_MASTER\n  emit TOGGLE_AIRCRAFT_EXIT 3\n  emit AXIS_ELEVATOR_SET -8000\n  emit SOME_EVENT 1 2 3 4 5"
+}
+func (c *emitCommand) Flags() *flag.FlagSet { return nil }
+
+func (c *emitCommand) Run(ctx context.Context, tc *terminal.Context) error {
+	if len(tc.Args) < 1 {
+		return fmt.Errorf("usage: emit <event-name> [data...]")
+	}
+
+	eventName := tc.Args[0]
+	dataArgs := tc.Args[1:]
+
+	if len(dataArgs) > 5 {
+		return fmt.Errorf("too many data values (max 5, got %d)", len(dataArgs))
+	}
+
+	dataValues, err := parseEventData(dataArgs)
+	if err != nil {
+		return err
+	}
+
+	// Create client with engine options and context
+	opts := append([]engine.Option{engine.WithContext(ctx)}, c.engineOpts...)
+	client := engine.New("SimVar CLI - Emit", opts...)
+
+	// Retry connection loop
+	fmt.Fprintf(tc.Stderr, "Connecting to simulator...\n")
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			if err := client.Connect(); err != nil {
+				fmt.Fprintf(tc.Stderr, "Connection failed: %v, retrying in 2s...\n", err)
+				time.Sleep(2 * time.Second)
+				continue
+			}
+			goto connected
+		}
+	}
+
+connected:
+	defer client.Disconnect()
+
+	// Wait for OPEN message to confirm connection
+	stream := client.Stream()
+	timer := time.NewTimer(time.Duration(c.timeout) * time.Second)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			return fmt.Errorf("timeout waiting for connection confirmation after %ds", c.timeout)
+		case msg, ok := <-stream:
+			if !ok {
+				return fmt.Errorf("stream closed unexpectedly")
+			}
+			if msg.Err != nil {
+				msg.Release()
+				continue
+			}
+			if types.SIMCONNECT_RECV_ID(msg.DwID) == types.SIMCONNECT_RECV_ID_OPEN {
+				msg.Release()
+				goto ready
+			}
+			msg.Release()
+		}
+	}
+
+ready:
+	// Map the event
+	mapping, err := getOrMapEvent(client, eventName)
+	if err != nil {
+		return err
+	}
+
+	// Setup notification group for emit
+	if err := client.AddClientEventToNotificationGroup(emitGroupID, mapping.eventID, false); err != nil {
+		return fmt.Errorf("AddClientEventToNotificationGroup: %w", err)
+	}
+	if err := client.SetNotificationGroupPriority(emitGroupID, 1); err != nil {
+		return fmt.Errorf("SetNotificationGroupPriority: %w", err)
+	}
+
+	// Transmit the event
+	if len(dataValues) <= 1 {
+		var data uint32
+		if len(dataValues) == 1 {
+			data = dataValues[0]
+		}
+		if err := client.TransmitClientEvent(
+			types.SIMCONNECT_OBJECT_ID_USER,
+			mapping.eventID,
+			data,
+			emitGroupID,
+			types.SIMCONNECT_EVENT_FLAG_GROUPID_IS_PRIORITY,
+		); err != nil {
+			return fmt.Errorf("TransmitClientEvent: %w", err)
+		}
+	} else {
+		var dataArray [5]uint32
+		for i, v := range dataValues {
+			dataArray[i] = v
+		}
+		if err := client.TransmitClientEventEx1(
+			types.SIMCONNECT_OBJECT_ID_USER,
+			mapping.eventID,
+			emitGroupID,
+			types.SIMCONNECT_EVENT_FLAG_GROUPID_IS_PRIORITY,
+			dataArray,
+		); err != nil {
+			return fmt.Errorf("TransmitClientEventEx1: %w", err)
+		}
+	}
+
+	// Wait briefly for exception response
+	exTimer := time.NewTimer(1 * time.Second)
+	defer exTimer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-exTimer.C:
+			fmt.Fprintf(tc.Stdout, "OK\n")
+			return nil
+		case msg, ok := <-stream:
+			if !ok {
+				return fmt.Errorf("stream closed unexpectedly")
+			}
+			if msg.Err != nil {
+				msg.Release()
+				continue
+			}
+			if types.SIMCONNECT_RECV_ID(msg.DwID) == types.SIMCONNECT_RECV_ID_EXCEPTION {
+				exc := msg.AsException()
+				if exc != nil {
+					err := fmt.Errorf("SimConnect exception: ID=%d, SendID=%d, Index=%d",
+						exc.DwException, exc.DwSendID, exc.DwIndex)
+					msg.Release()
+					return err
+				}
+			}
+			msg.Release()
+		}
+	}
+}

--- a/examples/simvar-cli/listen.go
+++ b/examples/simvar-cli/listen.go
@@ -1,0 +1,153 @@
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mrlm-net/cure/pkg/terminal"
+	"github.com/mrlm-net/simconnect/pkg/engine"
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+type listenCommand struct {
+	engineOpts []engine.Option
+	timeout    int
+}
+
+func (c *listenCommand) Name() string        { return "listen" }
+func (c *listenCommand) Description() string { return "Monitor client events from the simulator" }
+func (c *listenCommand) Usage() string {
+	return "listen <event-name> [event-name...]\n\nExamples:\n  listen GEAR_TOGGLE\n  listen AP_MASTER GEAR_TOGGLE"
+}
+func (c *listenCommand) Flags() *flag.FlagSet { return nil }
+
+func (c *listenCommand) Run(ctx context.Context, tc *terminal.Context) error {
+	if len(tc.Args) < 1 {
+		return fmt.Errorf("usage: listen <event-name> [event-name...]")
+	}
+
+	eventNames := tc.Args
+
+	// Create client with engine options and context
+	opts := append([]engine.Option{engine.WithContext(ctx)}, c.engineOpts...)
+	client := engine.New("SimVar CLI - Listen", opts...)
+
+	// Retry connection loop
+	fmt.Fprintf(tc.Stderr, "Connecting to simulator...\n")
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			if err := client.Connect(); err != nil {
+				fmt.Fprintf(tc.Stderr, "Connection failed: %v, retrying in 2s...\n", err)
+				time.Sleep(2 * time.Second)
+				continue
+			}
+			goto connected
+		}
+	}
+
+connected:
+	defer client.Disconnect()
+
+	// Wait for OPEN message to confirm connection
+	stream := client.Stream()
+	timer := time.NewTimer(time.Duration(c.timeout) * time.Second)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			return fmt.Errorf("timeout waiting for connection confirmation after %ds", c.timeout)
+		case msg, ok := <-stream:
+			if !ok {
+				return fmt.Errorf("stream closed unexpectedly")
+			}
+			if msg.Err != nil {
+				msg.Release()
+				continue
+			}
+			if types.SIMCONNECT_RECV_ID(msg.DwID) == types.SIMCONNECT_RECV_ID_OPEN {
+				msg.Release()
+				goto ready
+			}
+			msg.Release()
+		}
+	}
+
+ready:
+	// Build reverse map for event ID -> name lookup
+	reverseMap := make(map[uint32]string)
+
+	// Map each event and add to notification group
+	for _, name := range eventNames {
+		mapping, err := getOrMapEvent(client, name)
+		if err != nil {
+			return err
+		}
+		if err := client.AddClientEventToNotificationGroup(listenGroupID, mapping.eventID, false); err != nil {
+			return fmt.Errorf("AddClientEventToNotificationGroup(%s): %w", mapping.name, err)
+		}
+		reverseMap[mapping.eventID] = mapping.name
+	}
+
+	// Set notification group priority once
+	if err := client.SetNotificationGroupPriority(listenGroupID, listenGroupPriority); err != nil {
+		return fmt.Errorf("SetNotificationGroupPriority: %w", err)
+	}
+
+	// Collect names for display
+	names := make([]string, 0, len(eventNames))
+	for _, name := range eventNames {
+		names = append(names, strings.ToUpper(name))
+	}
+	fmt.Fprintf(tc.Stderr, "Listening for: %s (Ctrl+C to stop)\n", strings.Join(names, ", "))
+
+	// Stream loop
+	for {
+		select {
+		case <-ctx.Done():
+			// Cleanup notification group before exiting
+			client.ClearNotificationGroup(listenGroupID)
+			return nil
+		case msg, ok := <-stream:
+			if !ok {
+				client.ClearNotificationGroup(listenGroupID)
+				return nil
+			}
+			if msg.Err != nil {
+				msg.Release()
+				continue
+			}
+
+			switch types.SIMCONNECT_RECV_ID(msg.DwID) {
+			case types.SIMCONNECT_RECV_ID_EVENT:
+				evt := msg.AsEvent()
+				if evt != nil {
+					eid := uint32(evt.UEventID)
+					if name, ok := reverseMap[eid]; ok {
+						ts := time.Now().Format(time.RFC3339)
+						fmt.Fprintf(tc.Stdout, "[%s] %s data=%d\n", ts, name, uint32(evt.DwData))
+					}
+				}
+			case types.SIMCONNECT_RECV_ID_EXCEPTION:
+				exc := msg.AsException()
+				if exc != nil {
+					fmt.Fprintf(tc.Stderr, "Exception: ID=%d, SendID=%d, Index=%d\n",
+						exc.DwException, exc.DwSendID, exc.DwIndex)
+				}
+			}
+
+			msg.Release()
+		}
+	}
+}

--- a/examples/simvar-cli/main.go
+++ b/examples/simvar-cli/main.go
@@ -59,6 +59,8 @@ func main() {
 	// Register commands
 	router.Register(&getCommand{engineOpts: engineOpts, timeout: timeout})
 	router.Register(&setCommand{engineOpts: engineOpts, timeout: timeout})
+	router.Register(&emitCommand{engineOpts: engineOpts, timeout: timeout})
+	router.Register(&listenCommand{engineOpts: engineOpts, timeout: timeout})
 	router.Register(&replCommand{engineOpts: engineOpts, timeout: timeout})
 
 	// Setup signal handler context


### PR DESCRIPTION
## Summary
- Add `emit` command for firing client events via `TransmitClientEvent` (0-1 data params) and `TransmitClientEventEx1` (2-5 data params)
- Add `listen` command for monitoring client events via notification groups with real-time timestamped output
- Add REPL commands: `emit`, `listen`, `unlisten`, `listeners`, and `help`
- Shared event infrastructure with `sync.Map`-based cache for idempotent `MapClientEventToSimEvent` calls

## Changes

| File | What |
|------|------|
| `bridge.go` | Event mapping cache (`eventCache`), `getOrMapEvent()`, `parseEventData()`, group ID constants |
| `emit.go` | NEW -- standalone `emit` command (connect, map event, transmit, wait for exception) |
| `listen.go` | NEW -- standalone `listen` command (connect, map events, notification group, stream loop until Ctrl+C) |
| `main.go` | Register `emitCommand` and `listenCommand` with router |
| `repl.go` | Add `emit`/`listen`/`unlisten`/`listeners`/`help` dispatch, EVENT handling in consumer goroutine, cleanup on exit |
| `README.md` | Document new commands, updated REPL session examples, files table |

## Test plan
- [ ] `simvar-cli emit AP_MASTER` transmits with data=0, prints OK
- [ ] `simvar-cli emit TOGGLE_AIRCRAFT_EXIT 3` transmits with data=3
- [ ] `simvar-cli emit AXIS_ELEVATOR_SET -8000` accepts signed integer
- [ ] `simvar-cli emit SOME_EVENT 1 2 3 4 5` uses TransmitClientEventEx1
- [ ] `simvar-cli listen GEAR_TOGGLE` prints events until Ctrl+C
- [ ] `simvar-cli listen AP_MASTER GEAR_TOGGLE` subscribes to multiple events
- [ ] REPL `emit AP_MASTER 1` works within persistent session
- [ ] REPL `listen GEAR_TOGGLE` / `unlisten GEAR_TOGGLE` / `listeners` work correctly
- [ ] Duplicate `listen` prints informational message, does not re-map
- [ ] Self-echo: `listen AP_MASTER` then `emit AP_MASTER 1` shows event back
- [ ] `go build ./...` passes from `examples/simvar-cli`
- [ ] `go vet -unsafeptr=false ./...` passes

Closes #113