### PR TITLE
fix(examples): correct airport facility entry offset parsing for multi-entry responses

### DIFF
--- a/examples/all-facilities/main.go
+++ b/examples/all-facilities/main.go
@@ -16,15 +16,16 @@ import (
 	"github.com/mrlm-net/simconnect/pkg/types"
 )
 
-// AirportEntry represents a single airport facility entry (36 bytes total)
-// Must be packed to match exact memory layout from SimConnect
-type AirportEntry struct {
-	Ident  [6]byte // Offset 0-5
-	Region [3]byte // Offset 6-8
-	_      [3]byte // Offset 9-11 (padding)
-	Lat    float64 // Offset 12-19
-	Lon    float64 // Offset 20-27
-	Alt    float64 // Offset 28-35
+// airportWire8 reflects the 8-byte-aligned C layout used by MSFS 2024 (stride 40-41 bytes).
+// Field offsets are derived via unsafe.Offsetof rather than hardcoded magic numbers.
+// Do not cast this struct directly from SimConnect memory — use runtime stride arithmetic.
+type airportWire8 struct {
+	Ident  [6]byte  // Offset 0-5
+	Region [3]byte  // Offset 6-8
+	_      [7]byte  // Offset 9-15 (alignment padding for 8-byte double)
+	Lat    float64  // Offset 16-23
+	Lon    float64  // Offset 24-31
+	Alt    float64  // Offset 32-39
 }
 
 // runConnection handles a single connection lifecycle to the simulator.
@@ -118,25 +119,41 @@ connected:
 				actualEntrySize := actualDataSize / uintptr(list.DwArraySize)
 
 				fmt.Printf("  📏 Header size: %d bytes\n", headerSize)
-				fmt.Printf("  📏 Actual entry size: %d bytes\n", actualEntrySize)
-				fmt.Printf("  📏 Struct size: %d bytes\n", unsafe.Sizeof(AirportEntry{}))
+				fmt.Printf("  📏 Entry stride: %d bytes (from SimConnect)\n", actualEntrySize)
+
+				// Derive field offsets based on actual entry size reported by SimConnect.
+				var latOff, lonOff, altOff uintptr
+				switch actualEntrySize {
+				case 33: // 1-byte packing (no padding after Region)
+					latOff, lonOff, altOff = 9, 17, 25
+				case 36: // 4-byte alignment (3 bytes padding after Region)
+					latOff, lonOff, altOff = 12, 20, 28
+				case 40, 41: // 8-byte alignment (observed in MSFS 2024; 41 = 40 + trailing byte)
+					latOff = unsafe.Offsetof(airportWire8{}.Lat)
+					lonOff = unsafe.Offsetof(airportWire8{}.Lon)
+					altOff = unsafe.Offsetof(airportWire8{}.Alt)
+				default:
+					fmt.Fprintf(os.Stderr, "  ⚠️  Unrecognized entry size %d bytes — skipping batch\n", actualEntrySize)
+					continue
+				}
+
+				fmt.Printf("  📏 Field offsets: lat=%d, lon=%d, alt=%d\n", latOff, lonOff, altOff)
 
 				// dataStart points to the beginning of the array data (after the header)
 				dataStart := unsafe.Pointer(uintptr(unsafe.Pointer(list)) + headerSize)
 
 				for i := uint32(0); i < uint32(list.DwArraySize); i++ {
-					entryOffset := uintptr(i) * actualEntrySize
-					entryPtr := unsafe.Pointer(uintptr(dataStart) + entryOffset)
+					entryPtr := unsafe.Pointer(uintptr(dataStart) + uintptr(i)*actualEntrySize)
 
-					// Read fields at exact offsets - can't use struct due to Go's alignment rules
+					// Read fields at runtime-derived offsets
 					var ident [6]byte
 					var region [3]byte
 					copy(ident[:], (*[6]byte)(entryPtr)[:])
 					copy(region[:], (*[3]byte)(unsafe.Pointer(uintptr(entryPtr) + 6))[:])
 
-					lat := *(*float64)(unsafe.Pointer(uintptr(entryPtr) + 12))
-					lon := *(*float64)(unsafe.Pointer(uintptr(entryPtr) + 20))
-					alt := *(*float64)(unsafe.Pointer(uintptr(entryPtr) + 28))
+					lat := *(*float64)(unsafe.Pointer(uintptr(entryPtr) + latOff))
+					lon := *(*float64)(unsafe.Pointer(uintptr(entryPtr) + lonOff))
+					alt := *(*float64)(unsafe.Pointer(uintptr(entryPtr) + altOff))
 
 					fmt.Printf("  ✈️  Airport #%d: %s (%s) | 🌍 Lat: %.6f, Lon: %.6f | 📏 Alt: %.2fm\n",
 						i+1,

--- a/examples/subscribe-facilities/main.go
+++ b/examples/subscribe-facilities/main.go
@@ -16,13 +16,15 @@ import (
 	"github.com/mrlm-net/simconnect/pkg/types"
 )
 
-type AirportEntry struct {
-	Ident  [6]byte // Offset 0-5
-	Region [3]byte // Offset 6-8
-	_      [3]byte // Offset 9-11 (padding)
-	Lat    float64 // Offset 12-19
-	Lon    float64 // Offset 20-27
-	Alt    float64 // Offset 28-35
+// airportWire8 reflects the 8-byte-aligned C layout used by MSFS 2024 (stride 40-41 bytes).
+// Field offsets are derived via unsafe.Offsetof rather than hardcoded magic numbers.
+type airportWire8 struct {
+	Ident  [6]byte  // Offset 0-5
+	Region [3]byte  // Offset 6-8
+	_      [7]byte  // Offset 9-15 (alignment padding for 8-byte double)
+	Lat    float64  // Offset 16-23
+	Lon    float64  // Offset 24-31
+	Alt    float64  // Offset 32-39
 }
 
 // runConnection handles a single connection lifecycle to the simulator.
@@ -114,25 +116,41 @@ connected:
 				actualEntrySize := actualDataSize / uintptr(list.DwArraySize)
 
 				fmt.Printf("  📏 Header size: %d bytes\n", headerSize)
-				fmt.Printf("  📏 Actual entry size: %d bytes\n", actualEntrySize)
-				fmt.Printf("  📏 Struct size: %d bytes\n", unsafe.Sizeof(AirportEntry{}))
+				fmt.Printf("  📏 Entry stride: %d bytes (from SimConnect)\n", actualEntrySize)
+
+				// Derive field offsets based on actual entry size reported by SimConnect.
+				var latOff, lonOff, altOff uintptr
+				switch actualEntrySize {
+				case 33: // 1-byte packing (no padding after Region)
+					latOff, lonOff, altOff = 9, 17, 25
+				case 36: // 4-byte alignment (3 bytes padding after Region)
+					latOff, lonOff, altOff = 12, 20, 28
+				case 40, 41: // 8-byte alignment (observed in MSFS 2024; 41 = 40 + trailing byte)
+					latOff = unsafe.Offsetof(airportWire8{}.Lat)
+					lonOff = unsafe.Offsetof(airportWire8{}.Lon)
+					altOff = unsafe.Offsetof(airportWire8{}.Alt)
+				default:
+					fmt.Fprintf(os.Stderr, "  ⚠️  Unrecognized entry size %d bytes — skipping batch\n", actualEntrySize)
+					continue
+				}
+
+				fmt.Printf("  📏 Field offsets: lat=%d, lon=%d, alt=%d\n", latOff, lonOff, altOff)
 
 				// dataStart points to the beginning of the array data (after the header)
 				dataStart := unsafe.Pointer(uintptr(unsafe.Pointer(list)) + headerSize)
 
 				for i := uint32(0); i < uint32(list.DwArraySize); i++ {
-					entryOffset := uintptr(i) * actualEntrySize
-					entryPtr := unsafe.Pointer(uintptr(dataStart) + entryOffset)
+					entryPtr := unsafe.Pointer(uintptr(dataStart) + uintptr(i)*actualEntrySize)
 
-					// Read fields at exact offsets - can't use struct due to Go's alignment rules
+					// Read fields at runtime-derived offsets
 					var ident [6]byte
 					var region [3]byte
 					copy(ident[:], (*[6]byte)(entryPtr)[:])
 					copy(region[:], (*[3]byte)(unsafe.Pointer(uintptr(entryPtr) + 6))[:])
 
-					lat := *(*float64)(unsafe.Pointer(uintptr(entryPtr) + 12))
-					lon := *(*float64)(unsafe.Pointer(uintptr(entryPtr) + 20))
-					alt := *(*float64)(unsafe.Pointer(uintptr(entryPtr) + 28))
+					lat := *(*float64)(unsafe.Pointer(uintptr(entryPtr) + latOff))
+					lon := *(*float64)(unsafe.Pointer(uintptr(entryPtr) + lonOff))
+					alt := *(*float64)(unsafe.Pointer(uintptr(entryPtr) + altOff))
 
 					fmt.Printf("  ✈️  Airport #%d: %s (%s) | 🌍 Lat: %.6f, Lon: %.6f | 📏 Alt: %.2fm\n",
 						i+1,

--- a/pkg/types/facility.go
+++ b/pkg/types/facility.go
@@ -35,6 +35,15 @@ const (
 	SIMCONNECT_FACILITY_DATA_VASI
 )
 
+// SIMCONNECT_DATA_FACILITY_AIRPORT represents basic airport facility data.
+// C SDK field order: char Ident[6], char Region[3], double Latitude, double Longitude, double Altitude.
+// Go aligns the float64 fields to 8 bytes: unsafe.Sizeof = 40 on amd64.
+//
+// Note: MSFS 2024 reports a per-entry stride of 41 bytes in multi-entry AIRPORT_LIST
+// messages. Do not cast this struct directly from a multi-entry SimConnect buffer;
+// use runtime stride arithmetic with offset detection instead.
+// See examples/read-facilities for the reference implementation.
+//
 // https://docs.flightsimulator.com/msfs2024/html/6_Programming_APIs/SimConnect/API_Reference/Structures_And_Enumerations/SIMCONNECT_DATA_FACILITY_AIRPORT.htm
 type SIMCONNECT_DATA_FACILITY_AIRPORT struct {
 	Ident     [6]byte // char ident[6]


### PR DESCRIPTION
## Summary
- Fix struct alignment bug in airport facility entry parsing for multi-entry `SIMCONNECT_RECV_AIRPORT_LIST` responses
- SimConnect (MSFS 2024) reports 41-byte entries; code assumed 36-byte layout causing garbled data for entries 2+
- Replace hardcoded offsets (12/20/28) with runtime switch on `actualEntrySize` supporting 33/36/40/41-byte layouts
- Use `unsafe.Offsetof` from correctly-padded `airportWire8` struct for 8-byte alignment case
- Add stride warning comment to `SIMCONNECT_DATA_FACILITY_AIRPORT` type

## Files Changed
- `examples/read-facilities/main.go` — fix offset parsing (actively broken)
- `examples/all-facilities/main.go` — same fix (defensive, same code)
- `examples/subscribe-facilities/main.go` — same fix (defensive, same code)
- `pkg/types/facility.go` — add warning comment about 41-byte wire stride

## Test plan
- [ ] `go build ./...` passes clean
- [ ] `go vet -unsafeptr=false ./...` passes clean
- [ ] Run `read-facilities` against MSFS 2024 — verify all entries show valid ICAO/lat/lon/alt
- [ ] Run `all-facilities` and `subscribe-facilities` — verify no regression
- [ ] Verify diagnostic output shows correct stride and offsets

Closes #117