### PR TITLE
fix(examples): correct MSFS 2024 airport entry field offsets

### DIFF
--- a/examples/locate-airport/main.go
+++ b/examples/locate-airport/main.go
@@ -17,18 +17,6 @@ import (
 	"github.com/mrlm-net/simconnect/pkg/types"
 )
 
-// airportWire8 reflects the 8-byte-aligned C layout used by MSFS 2024 (stride 40-41 bytes).
-// Field offsets are derived via unsafe.Offsetof rather than hardcoded magic numbers.
-// Do not cast this struct directly from SimConnect memory — use runtime stride arithmetic.
-type airportWire8 struct {
-	Ident  [6]byte  // Offset 0-5
-	Region [3]byte  // Offset 6-8
-	_      [7]byte  // Offset 9-15 (alignment padding for 8-byte double)
-	Lat    float64  // Offset 16-23
-	Lon    float64  // Offset 24-31
-	Alt    float64  // Offset 32-39
-}
-
 // CameraData represents the data structure for CAMERA STATE and CAMERA SUBSTATE
 // The fields must match the order of AddToDataDefinition calls
 type CameraData struct {
@@ -268,13 +256,10 @@ connected:
 				// Derive field offsets based on actual entry size reported by SimConnect.
 				var latOff, lonOff uintptr
 				switch actualEntrySize {
-				case 33: // 1-byte packing (no padding after Region)
+				case 33: // MSFS 2020: ident[6] + region[3] + 3x float64 = 33
 					latOff, lonOff = 9, 17
-				case 36: // 4-byte alignment (3 bytes padding after Region)
+				case 36, 40, 41: // MSFS 2024: ident[9] + region[3] + 3x float64 = 36 (+trailing bytes)
 					latOff, lonOff = 12, 20
-				case 40, 41: // 8-byte alignment (observed in MSFS 2024; 41 = 40 + trailing byte)
-					latOff = unsafe.Offsetof(airportWire8{}.Lat)
-					lonOff = unsafe.Offsetof(airportWire8{}.Lon)
 				default:
 					fmt.Fprintf(os.Stderr, "  ⚠️  Unrecognized entry size %d bytes — skipping batch\n", actualEntrySize)
 					continue

--- a/examples/read-facilities/main.go
+++ b/examples/read-facilities/main.go
@@ -16,18 +16,6 @@ import (
 	"github.com/mrlm-net/simconnect/pkg/types"
 )
 
-// airportWire8 reflects the 8-byte-aligned C layout used by MSFS 2024 (stride 40-41 bytes).
-// Field offsets are derived via unsafe.Offsetof rather than hardcoded magic numbers.
-// Do not cast this struct directly from SimConnect memory — use runtime stride arithmetic.
-type airportWire8 struct {
-	Ident  [6]byte  // Offset 0-5
-	Region [3]byte  // Offset 6-8
-	_      [7]byte  // Offset 9-15 (alignment padding for 8-byte double)
-	Lat    float64  // Offset 16-23
-	Lon    float64  // Offset 24-31
-	Alt    float64  // Offset 32-39
-}
-
 // runConnection handles a single connection lifecycle to the simulator.
 // Returns nil when the simulator disconnects (allowing reconnection),
 // or an error if cancelled via context.
@@ -122,17 +110,15 @@ connected:
 				fmt.Printf("  📏 Entry stride: %d bytes (from SimConnect)\n", actualEntrySize)
 
 				// Derive field offsets based on actual entry size reported by SimConnect.
-				// Different MSFS versions may use different struct alignment/packing.
+				// MSFS 2020: char Ident[6] + char Region[3] = 9 bytes before doubles.
+				// MSFS 2024: char Ident[9] + char Region[3] = 12 bytes before doubles.
+				// Stride 41 = 36 data bytes + 5 trailing bytes (not prefix padding).
 				var latOff, lonOff, altOff uintptr
 				switch actualEntrySize {
-				case 33: // 1-byte packing (no padding after Region)
+				case 33: // MSFS 2020: ident[6] + region[3] + 3x float64 = 33
 					latOff, lonOff, altOff = 9, 17, 25
-				case 36: // 4-byte alignment (3 bytes padding after Region)
+				case 36, 40, 41: // MSFS 2024: ident[9] + region[3] + 3x float64 = 36 (+trailing bytes)
 					latOff, lonOff, altOff = 12, 20, 28
-				case 40, 41: // 8-byte alignment (observed in MSFS 2024; 41 = 40 + trailing byte)
-					latOff = unsafe.Offsetof(airportWire8{}.Lat)
-					lonOff = unsafe.Offsetof(airportWire8{}.Lon)
-					altOff = unsafe.Offsetof(airportWire8{}.Alt)
 				default:
 					fmt.Fprintf(os.Stderr, "  ⚠️  Unrecognized entry size %d bytes — skipping batch\n", actualEntrySize)
 					continue

--- a/examples/subscribe-facilities/main.go
+++ b/examples/subscribe-facilities/main.go
@@ -16,17 +16,6 @@ import (
 	"github.com/mrlm-net/simconnect/pkg/types"
 )
 
-// airportWire8 reflects the 8-byte-aligned C layout used by MSFS 2024 (stride 40-41 bytes).
-// Field offsets are derived via unsafe.Offsetof rather than hardcoded magic numbers.
-type airportWire8 struct {
-	Ident  [6]byte  // Offset 0-5
-	Region [3]byte  // Offset 6-8
-	_      [7]byte  // Offset 9-15 (alignment padding for 8-byte double)
-	Lat    float64  // Offset 16-23
-	Lon    float64  // Offset 24-31
-	Alt    float64  // Offset 32-39
-}
-
 // runConnection handles a single connection lifecycle to the simulator.
 // Returns nil when the simulator disconnects (allowing reconnection),
 // or an error if cancelled via context.
@@ -121,14 +110,10 @@ connected:
 				// Derive field offsets based on actual entry size reported by SimConnect.
 				var latOff, lonOff, altOff uintptr
 				switch actualEntrySize {
-				case 33: // 1-byte packing (no padding after Region)
+				case 33: // MSFS 2020: ident[6] + region[3] + 3x float64 = 33
 					latOff, lonOff, altOff = 9, 17, 25
-				case 36: // 4-byte alignment (3 bytes padding after Region)
+				case 36, 40, 41: // MSFS 2024: ident[9] + region[3] + 3x float64 = 36 (+trailing bytes)
 					latOff, lonOff, altOff = 12, 20, 28
-				case 40, 41: // 8-byte alignment (observed in MSFS 2024; 41 = 40 + trailing byte)
-					latOff = unsafe.Offsetof(airportWire8{}.Lat)
-					lonOff = unsafe.Offsetof(airportWire8{}.Lon)
-					altOff = unsafe.Offsetof(airportWire8{}.Alt)
 				default:
 					fmt.Fprintf(os.Stderr, "  ⚠️  Unrecognized entry size %d bytes — skipping batch\n", actualEntrySize)
 					continue

--- a/pkg/types/facility.go
+++ b/pkg/types/facility.go
@@ -39,8 +39,10 @@ const (
 // C SDK field order: char Ident[6], char Region[3], double Latitude, double Longitude, double Altitude.
 // Go aligns the float64 fields to 8 bytes: unsafe.Sizeof = 40 on amd64.
 //
-// Note: MSFS 2024 reports a per-entry stride of 41 bytes in multi-entry AIRPORT_LIST
-// messages. Do not cast this struct directly from a multi-entry SimConnect buffer;
+// Note: MSFS 2024 SDK uses char Ident[9] (not char Ident[6]), giving a wire layout
+// of ident[9] + region[3] + 3×float64 = 36 bytes. Multi-entry AIRPORT_LIST messages
+// from RequestFacilitiesListEX1 report a 41-byte stride (36 data + 5 trailing bytes).
+// Do not cast this struct directly from a multi-entry SimConnect buffer;
 // use runtime stride arithmetic with offset detection instead.
 // See examples/read-facilities for the reference implementation.
 //


### PR DESCRIPTION
## Summary
- Fixes wrong field offsets (16/24/32) introduced in v0.3.1 for 40/41-byte airport entry strides
- MSFS 2024 uses `char Ident[9]` (not `char[6]`), so layout is `ident[9] + region[3] = 12` bytes before doubles — correct offsets are 12/20/28
- Removes incorrect `airportWire8` struct from all 4 facility examples
- Merges cases 36/40/41 to share the same offsets (12/20/28)
- Updates `pkg/types/facility.go` comment to document the MSFS 2024 ident size difference

## Test plan
- [x] `read-facilities` — 542 airports, stride 36, all coordinates valid
- [x] `all-facilities` — 76 packets, all coordinates valid
- [x] `subscribe-facilities` — 76 packets, all coordinates valid
- [x] `locate-airport` — correctly found LKPR at 1.88km from LKPR
- [x] `go build ./...` passes
- [x] `go vet -unsafeptr=false ./...` passes

Closes #117