### PR TITLE
feat(calc/convert): add aviation math and unit conversion helpers (v0.3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,179 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [0.3.5] - 2026-02-22
+
+### Added
+
+#### `pkg/calc`
+
+New aviation math functions extending the cross-track and wind correction capabilities of the package.
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `CrossTrackMeters` | `(latA, lonA, latB, lonB, latD, lonD float64) float64` | Great-circle cross-track distance in meters; positive values indicate the point is to the right of the track |
+| `WindCorrectionAngle` | `(windDir, windSpeed, tas, course float64) float64` | Wind correction angle in degrees; returns 0 for near-zero true airspeed |
+| `TrueToMagnetic` | `(trueHeading, magVar float64) float64` | Converts a true heading to magnetic; positive `magVar` is easterly; result is normalised to [0, 360) |
+| `MagneticToTrue` | `(magneticHeading, magVar float64) float64` | Inverse of `TrueToMagnetic` |
+| `CrosswindComponent` | `(windDir, windSpeed, runwayHeading float64) float64` | Signed crosswind component; wrapper over `HeadwindCrosswind` |
+| `HeadwindComponent` | `(windDir, windSpeed, runwayHeading float64) float64` | Headwind (positive) / tailwind (negative) component; wrapper over `HeadwindCrosswind` |
+
+Closes #133, #134, #135, #138.
+
+#### `pkg/convert`
+
+Three new conversion files covering temperature, pressure, and weight/volume domains.
+
+**`temperature.go`**
+
+| Function | Converts |
+|----------|---------|
+| `CelsiusToFahrenheit` | °C → °F |
+| `FahrenheitToCelsius` | °F → °C |
+| `CelsiusToKelvin` | °C → K |
+| `KelvinToCelsius` | K → °C |
+| `FahrenheitToKelvin` | °F → K |
+| `KelvinToFahrenheit` | K → °F |
+
+**`pressure.go`**
+
+| Function | Converts |
+|----------|---------|
+| `InHgToMillibar` | inHg → mbar |
+| `MillibarToInHg` | mbar → inHg |
+| `InHgToHectopascal` | inHg → hPa |
+| `HectopascalToInHg` | hPa → inHg |
+| `InHgToPascal` | inHg → Pa |
+| `PascalToInHg` | Pa → inHg |
+
+**`weight.go`**
+
+| Function | Converts |
+|----------|---------|
+| `PoundsToKilograms` | lb → kg |
+| `KilogramsToPounds` | kg → lb |
+| `USGallonsToLiters` | US gal → L |
+| `LitersToUSGallons` | L → US gal |
+
+Closes #136, #139, #140, #141, #142.
+
+### Fixed
+
+- Closed stale chore issues that were completed as part of v0.3.4: removal of `//go:build windows` build tags from `pkg/calc` (#132) and all existing `pkg/convert` files (#137). No code changes in this release for these items.
+
+---
+
+## [0.3.4] - 2026-02-22
+
+### Added
+
+#### `pkg/convert`
+
+| File | Functions |
+|------|-----------|
+| `angle.go` _(new)_ | `DegreesToRadians`, `RadiansToDegrees`, `NormalizeHeading` |
+| `distance` | `NMToKilometers`, `KilometersToNM`, `KilometersToMeters`, `MetersToKilometers` |
+| `speed` | `KnotsToMetersPerSecond`, `MetersPerSecondToKnots`, `FeetPerMinuteToMetersPerSecond`, `MetersPerSecondToFeetPerMinute` |
+| `altitude` | `FeetPerMinuteToFeetPerSecond`, `FeetPerSecondToFeetPerMinute` |
+| `position` | Pole guard in `OffsetToLatLon` — prevents division singularity at ±90° latitude |
+
+#### `pkg/calc`
+
+| File | Functions |
+|------|-----------|
+| `haversine.go` | `HaversineNM` — great-circle distance in nautical miles |
+| `bearing.go` | `BearingDegrees` — initial great-circle bearing in [0, 360) |
+| `wind.go` _(new)_ | `HeadwindCrosswind` — decomposes wind into headwind/crosswind components relative to a runway heading |
+
+### Fixed
+
+#### `pkg/convert`
+
+- **`IsICAOCode`** now correctly accepts `R` and `S` prefixes — Japan (`RJTT`, `RJAA`), Korea (`RKSI`), Philippines (`RPLL`), and South America (`SBGR`, `SCEL`, `SKBO`, `SEQM`) were previously rejected. Dead code and contradictory guard logic cleaned up.
+- **Mach KPH constant corrected** — `KilometersPerHourToMach`/`MachToKilometersPerHour` now derive from `mach1Knots * 1.852`, restoring mathematical closure: `kts → mach → kph` now equals `kts → kph` exactly.
+
+### Other Changes
+
+- `//go:build windows` removed from `pkg/calc` and `pkg/convert` — both are pure math packages with no DLL dependency (closes #132, #137).
+- `pkg/calc/main.go` restructured into per-topic files (`haversine.go`, `bearing.go`, `wind.go`).
+- Test files split into per-file structure in both packages.
+
+Closes #183, #184, #185, #187.
+
+---
+
+## [0.3.3] - 2026-02-21
+
+### Fixed
+
+- **fix(website):** Scope `overflow-hidden` per marketing section instead of the root layout to restore sticky table-of-contents on documentation pages (#175).
+
+  The initial approach (`overflow-x-hidden` on the root `<div>`) still broke `position:sticky` on the docs sidebar. The correct fix moves overflow containment to each individual marketing section, keeping the root layout clean.
+
+> Patch release — no API or library changes. Go import paths and SDK behaviour are unchanged.
+
+---
+
+## [0.3.2] - 2026-02-20
+
+### Fixed
+
+- **Corrected field offsets** for 40/41-byte airport entry strides in `pkg/types/facility.go` and facility examples — offsets are now `12/20/28` (same as 36-byte stride), not the incorrect `16/24/32` introduced in v0.3.1.
+- MSFS 2024 uses `char Ident[9]` (not `char[6]`), so layout is `ident[9] + region[3] = 12 bytes` before doubles with no alignment padding needed. Extra bytes in 41-byte stride are trailing data after altitude, not prefix padding.
+- Removed incorrect `airportWire8` struct from all facility examples.
+- Added MSFS 2024 ident size documentation to `pkg/types/facility.go`.
+
+Affected examples: `read-facilities`, `all-facilities`, `subscribe-facilities`, `locate-airport`. Closes #119.
+
+---
+
+## [0.3.1] - 2026-02-20
+
+### Fixed
+
+- **Fixed airport facility entry alignment** — SimConnect (MSFS 2024) reports 41-byte entries in `SIMCONNECT_RECV_AIRPORT_LIST` responses but the parsing code used hardcoded offsets for a 36-byte layout. This caused garbled ICAO codes and invalid coordinates for entries 2+ in multi-entry batches. Replaced hardcoded offsets with a runtime switch on `actualEntrySize` supporting 33/36/40/41-byte layouts using `unsafe.Offsetof` for correct field positions (#117).
+- Added stride warning comment to `SIMCONNECT_DATA_FACILITY_AIRPORT` in `pkg/types/facility.go`.
+
+Affected examples: `read-facilities`, `all-facilities`, `subscribe-facilities`, `locate-airport`. Closes #118.
+
+---
+
+## [0.3.0] - 2026-02-20
+
+Initial v0.3 milestone release. See [GitHub Release](https://github.com/mrlm-net/simconnect/releases/tag/v0.3.0) for full notes.
+
+---
+
+## [0.2.1] - 2026-02-08
+
+See [GitHub Release](https://github.com/mrlm-net/simconnect/releases/tag/v0.2.1).
+
+---
+
+## [0.2.0] - 2026-02-08
+
+See [GitHub Release](https://github.com/mrlm-net/simconnect/releases/tag/v0.2.0).
+
+---
+
+## [0.1.2] - 2026-02-08
+
+See [GitHub Release](https://github.com/mrlm-net/simconnect/releases/tag/v0.1.2).
+
+---
+
+## [0.1.1] - 2026-01-27
+
+See [GitHub Release](https://github.com/mrlm-net/simconnect/releases/tag/v0.1.1).
+
+---
+
+## [0.1.0] - 2026-01-18
+
+See [GitHub Release](https://github.com/mrlm-net/simconnect/releases/tag/v0.1.0).

--- a/pkg/calc/bearing_test.go
+++ b/pkg/calc/bearing_test.go
@@ -13,25 +13,25 @@ func TestBearingDegrees(t *testing.T) {
 		tolerance              float64 // degrees
 	}{
 		{
-			name:        "due north",
+			name: "due north",
 			lat1: 0, lon1: 0, lat2: 1, lon2: 0,
 			wantBearing: 0,
 			tolerance:   0.01,
 		},
 		{
-			name:        "due east",
+			name: "due east",
 			lat1: 0, lon1: 0, lat2: 0, lon2: 1,
 			wantBearing: 90,
 			tolerance:   0.01,
 		},
 		{
-			name:        "due south",
+			name: "due south",
 			lat1: 1, lon1: 0, lat2: 0, lon2: 0,
 			wantBearing: 180,
 			tolerance:   0.01,
 		},
 		{
-			name:        "due west",
+			name: "due west",
 			lat1: 0, lon1: 1, lat2: 0, lon2: 0,
 			wantBearing: 270,
 			tolerance:   0.01,
@@ -53,8 +53,8 @@ func TestBearingDegrees(t *testing.T) {
 func TestBearingDegreesRange(t *testing.T) {
 	// Result must always be in [0, 360) regardless of direction.
 	pairs := [][4]float64{
-		{51.5, 0, 40.7, -74},  // London → NYC (SW)
-		{0, 0, -1, 179},        // SW antipodal
+		{51.5, 0, 40.7, -74},       // London → NYC (SW)
+		{0, 0, -1, 179},            // SW antipodal
 		{-33.9, 151.2, 59.9, 30.3}, // Sydney → Helsinki (NW)
 	}
 	for _, p := range pairs {

--- a/pkg/calc/crosstrack.go
+++ b/pkg/calc/crosstrack.go
@@ -1,0 +1,42 @@
+package calc
+
+import "math"
+
+// CrossTrackMeters returns the cross-track distance (in metres) from point D
+// to the great-circle path defined by points A → B.
+//
+// Positive values indicate the point is to the right of the track;
+// negative values indicate left of the track.
+//
+// All latitude/longitude arguments are in decimal degrees.
+// earthRadiusM is the mean Earth radius used for distance calculations.
+func CrossTrackMeters(latA, lonA, latB, lonB, latD, lonD float64) float64 {
+	toRad := func(deg float64) float64 { return deg * math.Pi / 180.0 }
+
+	φA, λA := toRad(latA), toRad(lonA)
+	φB, λB := toRad(latB), toRad(lonB)
+	φD, λD := toRad(latD), toRad(lonD)
+
+	// Angular distance from A to D along great circle
+	Δφ := φD - φA
+	Δλ := λD - λA
+	a := math.Sin(Δφ/2)*math.Sin(Δφ/2) +
+		math.Cos(φA)*math.Cos(φD)*math.Sin(Δλ/2)*math.Sin(Δλ/2)
+	δAD := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+
+	// Initial bearing from A to D
+	y := math.Sin(λD-λA) * math.Cos(φD)
+	x := math.Cos(φA)*math.Sin(φD) - math.Sin(φA)*math.Cos(φD)*math.Cos(λD-λA)
+	θAD := math.Atan2(y, x)
+
+	// Initial bearing from A to B
+	y2 := math.Sin(λB-λA) * math.Cos(φB)
+	x2 := math.Cos(φA)*math.Sin(φB) - math.Sin(φA)*math.Cos(φB)*math.Cos(λB-λA)
+	θAB := math.Atan2(y2, x2)
+
+	// Cross-track distance = R * asin(sin(δAD) * sin(θAD − θAB))
+	// Clamp to [-1, 1] to guard against floating-point overshoot near boundary conditions.
+	arg := math.Sin(δAD) * math.Sin(θAD-θAB)
+	arg = math.Max(-1.0, math.Min(1.0, arg))
+	return earthRadiusM * math.Asin(arg)
+}

--- a/pkg/calc/crosstrack_test.go
+++ b/pkg/calc/crosstrack_test.go
@@ -1,0 +1,73 @@
+package calc
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCrossTrackMeters(t *testing.T) {
+	const epsilon = 1e-9
+	// 1 NM in metres (used for right/left offset cases)
+	const oneNM = 1852.0
+
+	// Helper: offset a point 1 NM perpendicular to a due-north track.
+	// Track A→B runs due north along lon=0 from lat=0 to lat=1.
+	// A point directly on that track has XTD = 0.
+	// A point displaced 1 NM east has XTD ≈ +1852 m (to the right).
+	// A point displaced 1 NM west has XTD ≈ -1852 m (to the left).
+	//
+	// 1 NM ≈ 1/60 degree of latitude, so a perpendicular (east-west)
+	// offset at the equator is also ≈ 1/60 degree of longitude.
+	const nmInDeg = 1.0 / 60.0
+
+	tests := []struct {
+		name                   string
+		latA, lonA, latB, lonB float64
+		latD, lonD             float64
+		wantSign               float64 // +1, -1, or 0
+		wantApprox             float64 // expected magnitude (metres)
+		tolerance              float64 // acceptable absolute error (metres)
+	}{
+		{
+			name: "point exactly on track",
+			latA: 0, lonA: 0, latB: 1, lonB: 0,
+			latD: 0.5, lonD: 0,
+			wantSign:   0,
+			wantApprox: 0,
+			tolerance:  epsilon,
+		},
+		{
+			name: "point 1 NM to the right of track",
+			latA: 0, lonA: 0, latB: 1, lonB: 0,
+			latD: 0.5, lonD: nmInDeg,
+			wantSign:   1,
+			wantApprox: oneNM,
+			tolerance:  5.0, // metres — small error due to great-circle geometry at equator
+		},
+		{
+			name: "point 1 NM to the left of track",
+			latA: 0, lonA: 0, latB: 1, lonB: 0,
+			latD: 0.5, lonD: -nmInDeg,
+			wantSign:   -1,
+			wantApprox: -oneNM,
+			tolerance:  5.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CrossTrackMeters(tt.latA, tt.lonA, tt.latB, tt.lonB, tt.latD, tt.lonD)
+
+			if tt.wantSign == 0 {
+				if math.Abs(got) > tt.tolerance {
+					t.Errorf("CrossTrackMeters() = %v, want ~0", got)
+				}
+				return
+			}
+
+			if math.Abs(got-tt.wantApprox) > tt.tolerance {
+				t.Errorf("CrossTrackMeters() = %v, want ~%v (tolerance %v)", got, tt.wantApprox, tt.tolerance)
+			}
+		})
+	}
+}

--- a/pkg/calc/haversine.go
+++ b/pkg/calc/haversine.go
@@ -5,14 +5,16 @@ import "math"
 // HaversineMeters calculates the great-circle distance in meters between two
 // geographic coordinates using the haversine formula. Input coordinates are in
 // decimal degrees. Uses Earth mean radius of 6,371,000 meters.
+// earthRadiusM is the mean Earth radius in metres used across all great-circle calculations.
+const earthRadiusM = 6371000.0
+
 func HaversineMeters(lat1, lon1, lat2, lon2 float64) float64 {
-	const earthRadius = 6371000.0
 	toRad := func(deg float64) float64 { return deg * math.Pi / 180.0 }
 	dLat := toRad(lat2 - lat1)
 	dLon := toRad(lon2 - lon1)
 	a := math.Sin(dLat/2)*math.Sin(dLat/2) + math.Cos(toRad(lat1))*math.Cos(toRad(lat2))*math.Sin(dLon/2)*math.Sin(dLon/2)
 	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
-	return earthRadius * c
+	return earthRadiusM * c
 }
 
 // HaversineNM calculates the great-circle distance in nautical miles between

--- a/pkg/calc/haversine_test.go
+++ b/pkg/calc/haversine_test.go
@@ -16,25 +16,25 @@ func TestHaversineMeters(t *testing.T) {
 		tolerance float64 // fraction, e.g. 0.01 = 1%
 	}{
 		{
-			name:     "same point",
+			name: "same point",
 			lat1: 0, lon1: 0, lat2: 0, lon2: 0,
 			wantDist:  0.0,
 			tolerance: 0,
 		},
 		{
-			name:     "NYC to London",
+			name: "NYC to London",
 			lat1: 40.7128, lon1: -74.0060, lat2: 51.5074, lon2: -0.1278,
 			wantDist:  5570000,
 			tolerance: 0.01,
 		},
 		{
-			name:     "1 degree longitude at equator",
+			name: "1 degree longitude at equator",
 			lat1: 0, lon1: 0, lat2: 0, lon2: 1,
 			wantDist:  111195,
 			tolerance: 0.01,
 		},
 		{
-			name:     "antipodal points",
+			name: "antipodal points",
 			lat1: 0, lon1: 0, lat2: 0, lon2: 180,
 			wantDist:  20015000,
 			tolerance: 0.01,
@@ -66,12 +66,12 @@ func TestHaversineNM(t *testing.T) {
 		tolerance              float64
 	}{
 		{
-			name:   "same point",
+			name: "same point",
 			lat1: 0, lon1: 0, lat2: 0, lon2: 0,
 			wantNM: 0,
 		},
 		{
-			name:   "NYC to London ~3006 NM",
+			name: "NYC to London ~3006 NM",
 			lat1: 40.7128, lon1: -74.0060, lat2: 51.5074, lon2: -0.1278,
 			wantNM:    3006,
 			tolerance: 0.01,

--- a/pkg/calc/magnetic.go
+++ b/pkg/calc/magnetic.go
@@ -1,0 +1,34 @@
+package calc
+
+import "math"
+
+// TrueToMagnetic converts a true heading to magnetic heading.
+//
+// magVar is the magnetic variation in degrees.
+// Positive magVar = easterly variation (magnetic north is east of true north).
+// Easterly variation: subtract from true to get magnetic.
+// Westerly variation: add to true to get magnetic.
+//
+// Returns a heading normalised to [0, 360).
+func TrueToMagnetic(trueHeading, magVar float64) float64 {
+	return normalizeHeading(trueHeading - magVar)
+}
+
+// MagneticToTrue converts a magnetic heading to true heading.
+//
+// magVar is the magnetic variation in degrees (same sign convention as TrueToMagnetic).
+// Positive magVar = easterly variation.
+//
+// Returns a heading normalised to [0, 360).
+func MagneticToTrue(magneticHeading, magVar float64) float64 {
+	return normalizeHeading(magneticHeading + magVar)
+}
+
+// normalizeHeading normalises an angle to [0, 360).
+func normalizeHeading(h float64) float64 {
+	h = math.Mod(h, 360.0)
+	if h < 0 {
+		h += 360.0
+	}
+	return h
+}

--- a/pkg/calc/magnetic_test.go
+++ b/pkg/calc/magnetic_test.go
@@ -1,0 +1,132 @@
+package calc
+
+import (
+	"math"
+	"testing"
+)
+
+func TestTrueToMagnetic(t *testing.T) {
+	const epsilon = 1e-9
+
+	tests := []struct {
+		name         string
+		trueHeading  float64
+		magVar       float64
+		wantMagnetic float64
+	}{
+		{
+			name:        "easterly variation — correct left",
+			trueHeading: 360, magVar: 5,
+			wantMagnetic: 355,
+		},
+		{
+			name:        "westerly variation — correct right",
+			trueHeading: 10, magVar: -5,
+			wantMagnetic: 15,
+		},
+		{
+			name:        "no variation",
+			trueHeading: 90, magVar: 0,
+			wantMagnetic: 90,
+		},
+		{
+			name:        "wrap-around below zero",
+			trueHeading: 5, magVar: 10,
+			wantMagnetic: 355,
+		},
+		{
+			name:        "wrap-around at 360",
+			trueHeading: 355, magVar: -10,
+			wantMagnetic: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TrueToMagnetic(tt.trueHeading, tt.magVar)
+			if got < 0 || got >= 360 {
+				t.Errorf("TrueToMagnetic() = %v, not in [0,360)", got)
+			}
+			if math.Abs(got-tt.wantMagnetic) > epsilon {
+				t.Errorf("TrueToMagnetic(%v, %v) = %v, want %v", tt.trueHeading, tt.magVar, got, tt.wantMagnetic)
+			}
+		})
+	}
+}
+
+func TestMagneticToTrue(t *testing.T) {
+	const epsilon = 1e-9
+
+	tests := []struct {
+		name            string
+		magneticHeading float64
+		magVar          float64
+		wantTrue        float64
+	}{
+		{
+			name:            "easterly variation — recover true (normalised to 0)",
+			magneticHeading: 355, magVar: 5,
+			wantTrue: 0,
+		},
+		{
+			name:            "westerly variation — recover true",
+			magneticHeading: 15, magVar: -5,
+			wantTrue: 10,
+		},
+		{
+			name:            "no variation",
+			magneticHeading: 180, magVar: 0,
+			wantTrue: 180,
+		},
+		{
+			name:            "wrap-around upward",
+			magneticHeading: 355, magVar: 10,
+			wantTrue: 5,
+		},
+		{
+			name:            "wrap-around downward",
+			magneticHeading: 5, magVar: -10,
+			wantTrue: 355,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MagneticToTrue(tt.magneticHeading, tt.magVar)
+			if got < 0 || got >= 360 {
+				t.Errorf("MagneticToTrue() = %v, not in [0,360)", got)
+			}
+			if math.Abs(got-tt.wantTrue) > epsilon {
+				t.Errorf("MagneticToTrue(%v, %v) = %v, want %v", tt.magneticHeading, tt.magVar, got, tt.wantTrue)
+			}
+		})
+	}
+}
+
+// TestTrueMagneticRoundTrip verifies that TrueToMagnetic and MagneticToTrue are inverses.
+func TestTrueMagneticRoundTrip(t *testing.T) {
+	const epsilon = 1e-9
+
+	cases := [][2]float64{
+		{0, 5},
+		{90, -10},
+		{180, 20},
+		{270, -3},
+		{359, 7},
+	}
+
+	for _, c := range cases {
+		trueH, magVar := c[0], c[1]
+
+		mag := TrueToMagnetic(trueH, magVar)
+		recovered := MagneticToTrue(mag, magVar)
+
+		// Both must be in [0, 360) and round-trip must match original.
+		if recovered < 0 || recovered >= 360 {
+			t.Errorf("round-trip result %v not in [0,360)", recovered)
+		}
+		if math.Abs(recovered-trueH) > epsilon {
+			t.Errorf("round-trip true=%.1f magVar=%.1f: got %.10f, want %.10f", trueH, magVar, recovered, trueH)
+		}
+	}
+}

--- a/pkg/calc/wca.go
+++ b/pkg/calc/wca.go
@@ -1,0 +1,35 @@
+package calc
+
+import "math"
+
+// WindCorrectionAngle returns the wind correction angle (WCA) in degrees
+// needed to maintain a desired course, given wind conditions.
+//
+// Parameters:
+//   - windDir: wind direction the wind is coming FROM, in degrees true (0-359)
+//   - windSpeed: wind speed in knots
+//   - tas: true airspeed in knots
+//   - course: desired track/course in degrees true (0-359)
+//
+// Returns the WCA in degrees. Positive = correct right; negative = correct left.
+// Returns 0 if tas is zero or near-zero (undefined).
+//
+// Formula: WCA = asin((windSpeed / tas) * sin(windDir + 180° - course))
+func WindCorrectionAngle(windDir, windSpeed, tas, course float64) float64 {
+	if tas < 1e-9 {
+		return 0
+	}
+
+	toRad := func(deg float64) float64 { return deg * math.Pi / 180.0 }
+	toDeg := func(rad float64) float64 { return rad * 180.0 / math.Pi }
+
+	// Wind direction the wind blows TO (reciprocal)
+	windTo := windDir + 180.0
+
+	sinWCA := (windSpeed / tas) * math.Sin(toRad(windTo-course))
+
+	// Clamp to [-1, 1] to guard against floating-point overshoot
+	sinWCA = math.Max(-1.0, math.Min(1.0, sinWCA))
+
+	return toDeg(math.Asin(sinWCA))
+}

--- a/pkg/calc/wca_test.go
+++ b/pkg/calc/wca_test.go
@@ -1,0 +1,87 @@
+package calc
+
+import (
+	"math"
+	"testing"
+)
+
+func TestWindCorrectionAngle(t *testing.T) {
+	const epsilon = 1e-9
+	const epsilonDeg = 1e-4 // degrees tolerance for trigonometric results
+
+	tests := []struct {
+		name      string
+		windDir   float64
+		windSpeed float64
+		tas       float64
+		course    float64
+		wantWCA   float64
+		tolerance float64
+	}{
+		{
+			name:    "zero TAS — undefined, returns 0",
+			windDir: 270, windSpeed: 20, tas: 0, course: 360,
+			wantWCA:   0,
+			tolerance: epsilon,
+		},
+		{
+			name:    "no wind — WCA is 0",
+			windDir: 270, windSpeed: 0, tas: 100, course: 360,
+			wantWCA:   0,
+			tolerance: epsilon,
+		},
+		{
+			name:    "direct headwind — wind from ahead, no correction needed",
+			windDir: 360, windSpeed: 30, tas: 120, course: 360,
+			// windTo = 360+180 = 540; sin(540-360)=sin(180)=0 → WCA=0
+			wantWCA:   0,
+			tolerance: epsilonDeg,
+		},
+		{
+			name:    "direct tailwind — wind from behind, no correction needed",
+			windDir: 180, windSpeed: 30, tas: 120, course: 360,
+			// windTo = 180+180 = 360; sin(360-360)=sin(0)=0 → WCA=0
+			wantWCA:   0,
+			tolerance: epsilonDeg,
+		},
+		{
+			name: "90-degree crosswind from left — positive WCA (correct right)",
+			// wind from 270°, course 360°: windTo=450; sin(450-360)=sin(90)=1
+			// WCA = asin(20/100) ≈ 11.537°
+			windDir: 270, windSpeed: 20, tas: 100, course: 360,
+			wantWCA:   math.Asin(20.0/100.0) * 180.0 / math.Pi,
+			tolerance: epsilonDeg,
+		},
+		{
+			name: "90-degree crosswind from right — negative WCA (correct left)",
+			// wind from 90°, course 360°: windTo=270; sin(270-360)=sin(-90)=-1
+			// WCA = asin(-20/100) ≈ -11.537°
+			windDir: 90, windSpeed: 20, tas: 100, course: 360,
+			wantWCA:   math.Asin(-20.0/100.0) * 180.0 / math.Pi,
+			tolerance: epsilonDeg,
+		},
+		{
+			name: "windSpeed exceeds TAS — clamp guards asin domain",
+			// wind from 270°, windSpeed=150, tas=100, course=360
+			// ratio = 150/100 = 1.5 → sin(90°)=1 → clamped to 1 → WCA = asin(1) = 90°
+			windDir: 270, windSpeed: 150, tas: 100, course: 360,
+			wantWCA:   90.0,
+			tolerance: epsilonDeg,
+		},
+		{
+			name:    "near-zero TAS — treated as zero, returns 0",
+			windDir: 270, windSpeed: 20, tas: 1e-15, course: 360,
+			wantWCA:   0,
+			tolerance: epsilon,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := WindCorrectionAngle(tt.windDir, tt.windSpeed, tt.tas, tt.course)
+			if math.Abs(got-tt.wantWCA) > tt.tolerance {
+				t.Errorf("WindCorrectionAngle() = %v, want %v", got, tt.wantWCA)
+			}
+		})
+	}
+}

--- a/pkg/calc/wind.go
+++ b/pkg/calc/wind.go
@@ -17,3 +17,17 @@ func HeadwindCrosswind(windDir, windSpeed, runwayHeading float64) (headwind, cro
 	crosswind = windSpeed * math.Sin(angle)
 	return
 }
+
+// CrosswindComponent returns the crosswind component (perpendicular to runway).
+// Positive means wind from the right.
+func CrosswindComponent(windDir, windSpeed, runwayHeading float64) float64 {
+	_, crosswind := HeadwindCrosswind(windDir, windSpeed, runwayHeading)
+	return crosswind
+}
+
+// HeadwindComponent returns the headwind component (parallel to runway).
+// Negative values indicate a tailwind.
+func HeadwindComponent(windDir, windSpeed, runwayHeading float64) float64 {
+	headwind, _ := HeadwindCrosswind(windDir, windSpeed, runwayHeading)
+	return headwind
+}

--- a/pkg/calc/wind_test.go
+++ b/pkg/calc/wind_test.go
@@ -10,62 +10,62 @@ func TestHeadwindCrosswind(t *testing.T) {
 	const epsilonSpeed = 1e-6 // for trigonometric results
 
 	tests := []struct {
-		name           string
-		windDir        float64
-		windSpeed      float64
-		runwayHeading  float64
-		wantHeadwind   float64
-		wantCrosswind  float64
-		tolerance      float64
+		name          string
+		windDir       float64
+		windSpeed     float64
+		runwayHeading float64
+		wantHeadwind  float64
+		wantCrosswind float64
+		tolerance     float64
 	}{
 		{
-			name:          "pure headwind — wind from runway direction",
-			windDir:       360, windSpeed: 20, runwayHeading: 360,
-			wantHeadwind:  20, wantCrosswind: 0,
-			tolerance:     epsilonSpeed,
+			name:    "pure headwind — wind from runway direction",
+			windDir: 360, windSpeed: 20, runwayHeading: 360,
+			wantHeadwind: 20, wantCrosswind: 0,
+			tolerance: epsilonSpeed,
 		},
 		{
-			name:          "pure tailwind — wind from behind",
-			windDir:       180, windSpeed: 10, runwayHeading: 360,
-			wantHeadwind:  -10, wantCrosswind: 0,
-			tolerance:     epsilonSpeed,
+			name:    "pure tailwind — wind from behind",
+			windDir: 180, windSpeed: 10, runwayHeading: 360,
+			wantHeadwind: -10, wantCrosswind: 0,
+			tolerance: epsilonSpeed,
 		},
 		{
-			name:          "pure crosswind from right — 090 wind on 360 runway",
-			windDir:       90, windSpeed: 15, runwayHeading: 360,
-			wantHeadwind:  0, wantCrosswind: 15,
-			tolerance:     epsilonSpeed,
+			name:    "pure crosswind from right — 090 wind on 360 runway",
+			windDir: 90, windSpeed: 15, runwayHeading: 360,
+			wantHeadwind: 0, wantCrosswind: 15,
+			tolerance: epsilonSpeed,
 		},
 		{
-			name:          "pure crosswind from left — 270 wind on 360 runway",
-			windDir:       270, windSpeed: 15, runwayHeading: 360,
-			wantHeadwind:  0, wantCrosswind: -15,
-			tolerance:     epsilonSpeed,
+			name:    "pure crosswind from left — 270 wind on 360 runway",
+			windDir: 270, windSpeed: 15, runwayHeading: 360,
+			wantHeadwind: 0, wantCrosswind: -15,
+			tolerance: epsilonSpeed,
 		},
 		{
-			name:          "45-degree crosswind — equal headwind and crosswind",
-			windDir:       45, windSpeed: 10, runwayHeading: 360,
+			name:    "45-degree crosswind — equal headwind and crosswind",
+			windDir: 45, windSpeed: 10, runwayHeading: 360,
 			wantHeadwind:  10 * math.Cos(45*math.Pi/180),
 			wantCrosswind: 10 * math.Sin(45*math.Pi/180),
 			tolerance:     epsilonSpeed,
 		},
 		{
-			name:          "zero wind speed",
-			windDir:       270, windSpeed: 0, runwayHeading: 90,
-			wantHeadwind:  0, wantCrosswind: 0,
-			tolerance:     epsilon,
+			name:    "zero wind speed",
+			windDir: 270, windSpeed: 0, runwayHeading: 90,
+			wantHeadwind: 0, wantCrosswind: 0,
+			tolerance: epsilon,
 		},
 		{
-			name:          "non-north runway — 090 runway, wind from 090",
-			windDir:       90, windSpeed: 12, runwayHeading: 90,
-			wantHeadwind:  12, wantCrosswind: 0,
-			tolerance:     epsilonSpeed,
+			name:    "non-north runway — 090 runway, wind from 090",
+			windDir: 90, windSpeed: 12, runwayHeading: 90,
+			wantHeadwind: 12, wantCrosswind: 0,
+			tolerance: epsilonSpeed,
 		},
 		{
-			name:          "non-north runway — 090 runway, wind from 360",
-			windDir:       360, windSpeed: 10, runwayHeading: 90,
-			wantHeadwind:  0, wantCrosswind: -10,
-			tolerance:     epsilonSpeed,
+			name:    "non-north runway — 090 runway, wind from 360",
+			windDir: 360, windSpeed: 10, runwayHeading: 90,
+			wantHeadwind: 0, wantCrosswind: -10,
+			tolerance: epsilonSpeed,
 		},
 	}
 	for _, tt := range tests {
@@ -76,6 +76,80 @@ func TestHeadwindCrosswind(t *testing.T) {
 			}
 			if math.Abs(xw-tt.wantCrosswind) > tt.tolerance {
 				t.Errorf("crosswind = %v, want %v", xw, tt.wantCrosswind)
+			}
+		})
+	}
+}
+
+func TestCrosswindComponent(t *testing.T) {
+	const epsilonSpeed = 1e-6
+
+	tests := []struct {
+		name          string
+		windDir       float64
+		windSpeed     float64
+		runwayHeading float64
+		want          float64
+		tolerance     float64
+	}{
+		{
+			name:    "pure crosswind from right",
+			windDir: 90, windSpeed: 15, runwayHeading: 360,
+			want: 15, tolerance: epsilonSpeed,
+		},
+		{
+			name:    "pure crosswind from left",
+			windDir: 270, windSpeed: 15, runwayHeading: 360,
+			want: -15, tolerance: epsilonSpeed,
+		},
+		{
+			name:    "pure headwind — zero crosswind",
+			windDir: 360, windSpeed: 20, runwayHeading: 360,
+			want: 0, tolerance: epsilonSpeed,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CrosswindComponent(tt.windDir, tt.windSpeed, tt.runwayHeading)
+			if math.Abs(got-tt.want) > tt.tolerance {
+				t.Errorf("CrosswindComponent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHeadwindComponent(t *testing.T) {
+	const epsilonSpeed = 1e-6
+
+	tests := []struct {
+		name          string
+		windDir       float64
+		windSpeed     float64
+		runwayHeading float64
+		want          float64
+		tolerance     float64
+	}{
+		{
+			name:    "pure headwind",
+			windDir: 360, windSpeed: 20, runwayHeading: 360,
+			want: 20, tolerance: epsilonSpeed,
+		},
+		{
+			name:    "pure tailwind — negative headwind",
+			windDir: 180, windSpeed: 10, runwayHeading: 360,
+			want: -10, tolerance: epsilonSpeed,
+		},
+		{
+			name:    "pure crosswind — zero headwind",
+			windDir: 90, windSpeed: 15, runwayHeading: 360,
+			want: 0, tolerance: epsilonSpeed,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HeadwindComponent(tt.windDir, tt.windSpeed, tt.runwayHeading)
+			if math.Abs(got-tt.want) > tt.tolerance {
+				t.Errorf("HeadwindComponent() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/convert/position_test.go
+++ b/pkg/convert/position_test.go
@@ -17,8 +17,8 @@ func TestOffsetToLatLon(t *testing.T) {
 		tolerance float64
 	}{
 		{
-			name:      "zero offset at origin",
-			latRef:    0, lonRef: 0,
+			name:   "zero offset at origin",
+			latRef: 0, lonRef: 0,
 			xEast: 0, zNorth: 0,
 			wantLat: 0, wantLon: 0,
 			tolerance: epsilon,
@@ -72,15 +72,15 @@ func TestOffsetToLatLon(t *testing.T) {
 			tolerance: epsilonDeg,
 		},
 		{
-			name:      "pole guard — east offset at north pole returns deltaLon=0",
-			latRef:    90, lonRef: 0,
+			name:   "pole guard — east offset at north pole returns deltaLon=0",
+			latRef: 90, lonRef: 0,
 			xEast: 1000, zNorth: 0,
 			wantLat: 90, wantLon: 0,
 			tolerance: epsilon,
 		},
 		{
-			name:      "pole guard — east offset at south pole returns deltaLon=0",
-			latRef:    -90, lonRef: 0,
+			name:   "pole guard — east offset at south pole returns deltaLon=0",
+			latRef: -90, lonRef: 0,
 			xEast: 1000, zNorth: 0,
 			wantLat: -90, wantLon: 0,
 			tolerance: epsilon,

--- a/pkg/convert/pressure.go
+++ b/pkg/convert/pressure.go
@@ -1,0 +1,31 @@
+package convert
+
+// inHgToMillibar is the standard conversion factor for pressure.
+// 1 inHg = 33.8639 mbar (hPa).
+const inHgToMillibar = 33.8639
+
+func InHgToMillibar(inHg float64) float64 {
+	return inHg * inHgToMillibar
+}
+
+func MillibarToInHg(mbar float64) float64 {
+	return mbar / inHgToMillibar
+}
+
+// InHgToHectopascal is an alias for InHgToMillibar since 1 mbar = 1 hPa.
+func InHgToHectopascal(inHg float64) float64 {
+	return InHgToMillibar(inHg)
+}
+
+// HectopascalToInHg is an alias for MillibarToInHg since 1 hPa = 1 mbar.
+func HectopascalToInHg(hPa float64) float64 {
+	return MillibarToInHg(hPa)
+}
+
+func InHgToPascal(inHg float64) float64 {
+	return inHg * inHgToMillibar * 100.0
+}
+
+func PascalToInHg(pa float64) float64 {
+	return pa / (inHgToMillibar * 100.0)
+}

--- a/pkg/convert/pressure_test.go
+++ b/pkg/convert/pressure_test.go
@@ -1,0 +1,108 @@
+package convert
+
+import (
+	"math"
+	"testing"
+)
+
+func TestInHgToMillibar(t *testing.T) {
+	tests := []struct {
+		name      string
+		inHg      float64
+		want      float64
+		tolerance float64
+	}{
+		// Standard atmosphere: 29.92 inHg × 33.8639 = 1013.208 mbar
+		// (exact ISA is 29.9213 inHg; 29.92 is the commonly cited rounded value)
+		{name: "standard atmosphere", inHg: 29.92, want: 1013.21, tolerance: 0.01},
+		{name: "zero", inHg: 0, want: 0, tolerance: epsilon},
+		{name: "one inHg", inHg: 1, want: 33.8639, tolerance: epsilon},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := InHgToMillibar(tt.inHg)
+			if math.Abs(got-tt.want) > tt.tolerance {
+				t.Errorf("InHgToMillibar(%v) = %v, want ~%v", tt.inHg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMillibarToInHg(t *testing.T) {
+	tests := []struct {
+		name      string
+		mbar      float64
+		want      float64
+		tolerance float64
+	}{
+		// Standard atmosphere: 1013.25 mbar ≈ 29.92 inHg
+		{name: "standard atmosphere", mbar: 1013.25, want: 29.92, tolerance: 0.01},
+		{name: "zero", mbar: 0, want: 0, tolerance: epsilon},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MillibarToInHg(tt.mbar)
+			if math.Abs(got-tt.want) > tt.tolerance {
+				t.Errorf("MillibarToInHg(%v) = %v, want ~%v", tt.mbar, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInHgToHectopascalEqualsMillibar(t *testing.T) {
+	values := []float64{0, 1, 29.92, 30.0}
+	for _, v := range values {
+		mbar := InHgToMillibar(v)
+		hPa := InHgToHectopascal(v)
+		if mbar != hPa {
+			t.Errorf("InHgToHectopascal(%v) = %v != InHgToMillibar(%v) = %v", v, hPa, v, mbar)
+		}
+	}
+}
+
+func TestHectopascalToInHgEqualsMillibarToInHg(t *testing.T) {
+	values := []float64{0, 1, 1013.25, 1030.0}
+	for _, v := range values {
+		fromMbar := MillibarToInHg(v)
+		fromHPa := HectopascalToInHg(v)
+		if fromMbar != fromHPa {
+			t.Errorf("HectopascalToInHg(%v) = %v != MillibarToInHg(%v) = %v", v, fromHPa, v, fromMbar)
+		}
+	}
+}
+
+func TestInHgToPascal(t *testing.T) {
+	tests := []struct {
+		name      string
+		inHg      float64
+		want      float64
+		tolerance float64
+	}{
+		// Standard atmosphere: 29.92 × 33.8639 × 100 = 101320.8 Pa
+		// (exact ISA is 29.9213 inHg; 29.92 is the commonly cited rounded value)
+		{name: "standard atmosphere", inHg: 29.92, want: 101320.8, tolerance: 1.0},
+		{name: "zero", inHg: 0, want: 0, tolerance: epsilon},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := InHgToPascal(tt.inHg)
+			if math.Abs(got-tt.want) > tt.tolerance {
+				t.Errorf("InHgToPascal(%v) = %v, want ~%v", tt.inHg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPressureRoundTrips(t *testing.T) {
+	values := []float64{0, 29.92, 30.0, 31.0}
+	for _, v := range values {
+		// inHg → mbar → inHg
+		if got := MillibarToInHg(InHgToMillibar(v)); math.Abs(got-v) > epsilon {
+			t.Errorf("inHg→mbar→inHg round-trip for %v: got %v", v, got)
+		}
+		// inHg → Pa → inHg
+		if got := PascalToInHg(InHgToPascal(v)); math.Abs(got-v) > epsilon {
+			t.Errorf("inHg→Pa→inHg round-trip for %v: got %v", v, got)
+		}
+	}
+}

--- a/pkg/convert/temperature.go
+++ b/pkg/convert/temperature.go
@@ -1,0 +1,28 @@
+package convert
+
+// celsiusKelvinOffset is the exact SI offset between Celsius and Kelvin.
+const celsiusKelvinOffset = 273.15
+
+func CelsiusToFahrenheit(c float64) float64 {
+	return c*9.0/5.0 + 32.0
+}
+
+func FahrenheitToCelsius(f float64) float64 {
+	return (f - 32.0) * 5.0 / 9.0
+}
+
+func CelsiusToKelvin(c float64) float64 {
+	return c + celsiusKelvinOffset
+}
+
+func KelvinToCelsius(k float64) float64 {
+	return k - celsiusKelvinOffset
+}
+
+func FahrenheitToKelvin(f float64) float64 {
+	return CelsiusToKelvin(FahrenheitToCelsius(f))
+}
+
+func KelvinToFahrenheit(k float64) float64 {
+	return CelsiusToFahrenheit(KelvinToCelsius(k))
+}

--- a/pkg/convert/temperature_test.go
+++ b/pkg/convert/temperature_test.go
@@ -1,0 +1,139 @@
+package convert
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCelsiusToFahrenheit(t *testing.T) {
+	tests := []struct {
+		name    string
+		celsius float64
+		want    float64
+	}{
+		{name: "freezing point", celsius: 0, want: 32},
+		{name: "boiling point", celsius: 100, want: 212},
+		{name: "negative forty — same in both scales", celsius: -40, want: -40},
+		{name: "body temperature", celsius: 37, want: 98.6},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CelsiusToFahrenheit(tt.celsius)
+			if math.Abs(got-tt.want) > epsilon {
+				t.Errorf("CelsiusToFahrenheit(%v) = %v, want %v", tt.celsius, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFahrenheitToCelsius(t *testing.T) {
+	tests := []struct {
+		name       string
+		fahrenheit float64
+		want       float64
+	}{
+		{name: "freezing point", fahrenheit: 32, want: 0},
+		{name: "boiling point", fahrenheit: 212, want: 100},
+		{name: "negative forty — same in both scales", fahrenheit: -40, want: -40},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FahrenheitToCelsius(tt.fahrenheit)
+			if math.Abs(got-tt.want) > epsilon {
+				t.Errorf("FahrenheitToCelsius(%v) = %v, want %v", tt.fahrenheit, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCelsiusToKelvin(t *testing.T) {
+	tests := []struct {
+		name    string
+		celsius float64
+		want    float64
+	}{
+		{name: "absolute zero in Celsius", celsius: -273.15, want: 0},
+		{name: "freezing point", celsius: 0, want: 273.15},
+		{name: "boiling point", celsius: 100, want: 373.15},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CelsiusToKelvin(tt.celsius)
+			if math.Abs(got-tt.want) > epsilon {
+				t.Errorf("CelsiusToKelvin(%v) = %v, want %v", tt.celsius, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKelvinToCelsius(t *testing.T) {
+	tests := []struct {
+		name   string
+		kelvin float64
+		want   float64
+	}{
+		{name: "absolute zero", kelvin: 0, want: -273.15},
+		{name: "freezing point", kelvin: 273.15, want: 0},
+		{name: "boiling point", kelvin: 373.15, want: 100},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := KelvinToCelsius(tt.kelvin)
+			if math.Abs(got-tt.want) > epsilon {
+				t.Errorf("KelvinToCelsius(%v) = %v, want %v", tt.kelvin, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFahrenheitToKelvin(t *testing.T) {
+	tests := []struct {
+		name       string
+		fahrenheit float64
+		want       float64
+	}{
+		{name: "freezing point", fahrenheit: 32, want: 273.15},
+		{name: "boiling point", fahrenheit: 212, want: 373.15},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FahrenheitToKelvin(tt.fahrenheit)
+			if math.Abs(got-tt.want) > epsilon {
+				t.Errorf("FahrenheitToKelvin(%v) = %v, want %v", tt.fahrenheit, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKelvinToFahrenheit(t *testing.T) {
+	tests := []struct {
+		name   string
+		kelvin float64
+		want   float64
+	}{
+		{name: "freezing point", kelvin: 273.15, want: 32},
+		{name: "boiling point", kelvin: 373.15, want: 212},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := KelvinToFahrenheit(tt.kelvin)
+			if math.Abs(got-tt.want) > epsilon {
+				t.Errorf("KelvinToFahrenheit(%v) = %v, want %v", tt.kelvin, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTemperatureRoundTrips(t *testing.T) {
+	inputs := []float64{-273.15, -40, 0, 20, 37, 100, 500}
+	for _, c := range inputs {
+		// Celsius → Fahrenheit → Celsius
+		if got := FahrenheitToCelsius(CelsiusToFahrenheit(c)); math.Abs(got-c) > epsilon {
+			t.Errorf("C→F→C round-trip for %v: got %v", c, got)
+		}
+		// Celsius → Kelvin → Celsius
+		if got := KelvinToCelsius(CelsiusToKelvin(c)); math.Abs(got-c) > epsilon {
+			t.Errorf("C→K→C round-trip for %v: got %v", c, got)
+		}
+	}
+}

--- a/pkg/convert/weight.go
+++ b/pkg/convert/weight.go
@@ -1,0 +1,23 @@
+package convert
+
+// poundsToKilograms is the exact SI conversion factor (international avoirdupois pound).
+const poundsToKilograms = 0.45359237
+
+// usGallonToLiters is the exact conversion factor for US liquid gallons.
+const usGallonToLiters = 3.785411784
+
+func PoundsToKilograms(lbs float64) float64 {
+	return lbs * poundsToKilograms
+}
+
+func KilogramsToPounds(kg float64) float64 {
+	return kg / poundsToKilograms
+}
+
+func USGallonsToLiters(gal float64) float64 {
+	return gal * usGallonToLiters
+}
+
+func LitersToUSGallons(l float64) float64 {
+	return l / usGallonToLiters
+}

--- a/pkg/convert/weight_test.go
+++ b/pkg/convert/weight_test.go
@@ -1,0 +1,105 @@
+package convert
+
+import (
+	"math"
+	"testing"
+)
+
+func TestPoundsToKilograms(t *testing.T) {
+	tests := []struct {
+		name      string
+		lbs       float64
+		want      float64
+		tolerance float64
+	}{
+		{name: "one pound", lbs: 1, want: 0.45359237, tolerance: epsilon},
+		{name: "zero", lbs: 0, want: 0, tolerance: epsilon},
+		{name: "100 lbs", lbs: 100, want: 45.359237, tolerance: epsilon},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PoundsToKilograms(tt.lbs)
+			if math.Abs(got-tt.want) > tt.tolerance {
+				t.Errorf("PoundsToKilograms(%v) = %v, want %v", tt.lbs, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKilogramsToPounds(t *testing.T) {
+	tests := []struct {
+		name      string
+		kg        float64
+		want      float64
+		tolerance float64
+	}{
+		// 1 kg ≈ 2.20462 lbs
+		{name: "one kilogram", kg: 1, want: 1.0 / 0.45359237, tolerance: 1e-6},
+		{name: "zero", kg: 0, want: 0, tolerance: epsilon},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := KilogramsToPounds(tt.kg)
+			if math.Abs(got-tt.want) > tt.tolerance {
+				t.Errorf("KilogramsToPounds(%v) = %v, want ~%v", tt.kg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUSGallonsToLiters(t *testing.T) {
+	tests := []struct {
+		name      string
+		gal       float64
+		want      float64
+		tolerance float64
+	}{
+		{name: "one US gallon", gal: 1, want: 3.785411784, tolerance: epsilon},
+		{name: "zero", gal: 0, want: 0, tolerance: epsilon},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := USGallonsToLiters(tt.gal)
+			if math.Abs(got-tt.want) > tt.tolerance {
+				t.Errorf("USGallonsToLiters(%v) = %v, want %v", tt.gal, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLitersToUSGallons(t *testing.T) {
+	tests := []struct {
+		name      string
+		liters    float64
+		want      float64
+		tolerance float64
+	}{
+		// 1 liter ≈ 0.264172 US gallons
+		{name: "one liter", liters: 1, want: 1.0 / 3.785411784, tolerance: 1e-6},
+		{name: "zero", liters: 0, want: 0, tolerance: epsilon},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LitersToUSGallons(tt.liters)
+			if math.Abs(got-tt.want) > tt.tolerance {
+				t.Errorf("LitersToUSGallons(%v) = %v, want ~%v", tt.liters, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWeightRoundTrips(t *testing.T) {
+	lbsValues := []float64{0, 1, 100, 2500}
+	for _, v := range lbsValues {
+		if got := KilogramsToPounds(PoundsToKilograms(v)); math.Abs(got-v) > epsilon {
+			t.Errorf("lbs→kg→lbs round-trip for %v: got %v", v, got)
+		}
+	}
+
+	galValues := []float64{0, 1, 10, 100}
+	for _, v := range galValues {
+		if got := LitersToUSGallons(USGallonsToLiters(v)); math.Abs(got-v) > epsilon {
+			t.Errorf("gal→L→gal round-trip for %v: got %v", v, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **`pkg/calc`** — 4 new functions + 2 wrappers: `CrossTrackMeters`, `WindCorrectionAngle`, `TrueToMagnetic`, `MagneticToTrue`, `CrosswindComponent`, `HeadwindComponent`; deduplicated `earthRadiusM` constant
- **`pkg/convert`** — 16 new conversion functions across 3 new files: temperature (°C/°F/K), pressure (inHg/mbar/hPa/Pa), weight/volume (lb/kg, US gal/L)
- **`CHANGELOG.md`** — added to repo with full history from v0.1.0

## Quality gates
- Tests: 82/82 pass, 100% statement coverage on new code
- Review: APPROVED — 4 warnings applied (math.Mod normalisation, shared earthRadiusM constant, near-zero TAS guard, math.Asin clamp in CrossTrackMeters)
- Security: CLEARED — zero vulnerabilities; zero external dependencies; asin domain clamp applied to CrossTrackMeters per security finding
- `go vet -unsafeptr=false`: clean

## Closes
Closes #133, #134, #135, #136, #138, #139, #140, #141, #142