### PR TITLE
fix(examples/engine): manage-traffic rewrite + AI waypoint helpers (v0.3.7)

### DIFF
--- a/pkg/types/data.go
+++ b/pkg/types/data.go
@@ -81,6 +81,15 @@ const (
 )
 
 // https://docs.flightsimulator.com/html/Programming_Tools/SimConnect/API_Reference/Structures_And_Enumerations/SIMCONNECT_DATA_WAYPOINT.htm
+//
+// WARNING: SimConnect.h wraps all structures in #pragma pack(push, 1), so the
+// C wire layout is 44 bytes — Flags (uint32) at offset 24 is directly followed
+// by ktsSpeed (float64) at offset 28 with NO padding.  Go's natural alignment
+// inserts 4 bytes of padding after Flags, making sizeof == 48.
+//
+// Do NOT pass a []SIMCONNECT_DATA_WAYPOINT slice directly to SetDataOnSimObject
+// via unsafe.Pointer — use engine.PackWaypoints to produce the correct 44-byte-
+// per-element packed buffer first.
 type SIMCONNECT_DATA_WAYPOINT struct {
 	Latitude        float64 // double Latitude
 	Longitude       float64 // double Longitude


### PR DESCRIPTION
## Summary

- Complete rewrite of `examples/manage-traffic` using live LKPR facility data (airport reference, parking, taxi graph, runways)
- Spawns 5 parked gate aircraft, 1 taxi aircraft on a real taxiway chain, 1 departing aircraft (250 m lineup taxi → full takeoff roll → climb)
- Correct `ASSIGNED_OBJECT_ID` pattern + `AIReleaseControl` before sending AI Waypoint List
- Waypoints use `COMPUTE_VERTICAL_SPEED | ALTITUDE_IS_AGL | THROTTLE_REQUESTED` for realistic climb rates
- `parseRunway()`: runway `HEADING`/`LENGTH` are `float32` on the wire — manual binary parsing fixes garbage reads
- `PackWaypoints()` in `pkg/engine/message.go`: `SIMCONNECT_DATA_WAYPOINT` is 44 bytes wire / 48 bytes Go — prevents `INVALID_DATA_SIZE` exception
- `AsAssignedObjectID()` and `AsFacilityDataEnd()` helpers added to `pkg/engine/message.go`
- `SIGTERM` handled alongside `SIGINT` so process termination triggers `AIRemoveObject` cleanup

## Test plan

- [ ] Build passes: `go build ./...`
- [ ] Run example against live MSFS: `go run ./examples/manage-traffic`
- [ ] Verify gate aircraft spawn at correct LKPR positions
- [ ] Verify taxi aircraft follows taxi graph
- [ ] Verify takeoff aircraft taxis to lineup then rolls and climbs on runway heading
- [ ] Verify all aircraft removed on Ctrl+C or process kill