### PR TITLE
feat(flow/flight): add Flow Event API and manager flight delegation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ website/.svelte-kit/
 .mrlm
 .playwright-mcp
 website/sbom-npm.json
+
+examples/**/*.gpx
+examples/**/*.csv
+examples/**/*.json

--- a/examples/flow-events/main.go
+++ b/examples/flow-events/main.go
@@ -1,0 +1,130 @@
+//go:build windows
+// +build windows
+
+// ⚠️  MSFS 2024 ONLY — SimConnect_SubscribeToFlowEvent and
+// SimConnect_UnsubscribeToFlowEvent are available in Microsoft Flight Simulator 2024
+// only and will return E_FAIL on Microsoft Flight Simulator 2020.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/mrlm-net/simconnect"
+	"github.com/mrlm-net/simconnect/pkg/engine"
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+func runConnection(ctx context.Context) error {
+	client := simconnect.NewClient("GO Example - Flow Events",
+		engine.WithContext(ctx),
+	)
+
+	fmt.Println("⏳ Waiting for simulator...")
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			if err := client.Connect(); err != nil {
+				fmt.Printf("🔄 Retrying in 2s: %v\n", err)
+				time.Sleep(2 * time.Second)
+				continue
+			}
+			goto connected
+		}
+	}
+
+connected:
+	fmt.Println("✅ Connected to SimConnect")
+
+	// Subscribe to all flow events. A single call covers all SIMCONNECT_FLOW_EVENT
+	// values; there is no per-event filtering at the subscription level.
+	if err := client.SubscribeToFlowEvent(); err != nil {
+		fmt.Fprintf(os.Stderr, "❌ SubscribeToFlowEvent: %v\n", err)
+		fmt.Fprintf(os.Stderr, "   (Running on MSFS 2020? Flow events require MSFS 2024.)\n")
+	} else {
+		fmt.Println("📡 Subscribed to flow events — waiting for simulator activity...")
+	}
+
+	stream := client.Stream()
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println("🔌 Shutting down...")
+			if err := client.UnsubscribeFromFlowEvent(); err != nil {
+				fmt.Fprintf(os.Stderr, "⚠️  UnsubscribeFromFlowEvent: %v\n", err)
+			}
+			if err := client.Disconnect(); err != nil {
+				fmt.Fprintf(os.Stderr, "❌ Disconnect: %v\n", err)
+			}
+			return ctx.Err()
+
+		case msg, ok := <-stream:
+			if !ok {
+				fmt.Println("📴 Stream closed (simulator disconnected)")
+				return nil
+			}
+			if msg.Err != nil {
+				fmt.Fprintf(os.Stderr, "❌ Stream error: %v\n", msg.Err)
+				continue
+			}
+
+			switch types.SIMCONNECT_RECV_ID(msg.DwID) {
+
+			case types.SIMCONNECT_RECV_ID_OPEN:
+				o := msg.AsOpen()
+				fmt.Printf("🟢 Simulator: %s v%d.%d\n",
+					engine.BytesToString(o.SzApplicationName[:]),
+					o.DwApplicationVersionMajor, o.DwApplicationVersionMinor)
+
+			case types.SIMCONNECT_RECV_ID_FLOW_EVENT:
+				fe := msg.AsFlowEvent()
+				path := engine.BytesToString(fe.FltPath[:])
+				if path == "" {
+					path = "(none)"
+				}
+				fmt.Printf("🌊 Flow event: %-24s  flt=%s\n", fe.FlowEvent, path)
+
+			case types.SIMCONNECT_RECV_ID_EXCEPTION:
+				ex := msg.AsException()
+				fmt.Printf("🚨 SimConnect exception %d at send index %d\n",
+					ex.DwException, ex.DwIndex)
+			}
+		}
+	}
+}
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		fmt.Println("🛑 Interrupt received, shutting down...")
+		cancel()
+	}()
+
+	fmt.Println("ℹ️  Press Ctrl+C to exit")
+	fmt.Println("⚠️  MSFS 2024 only — will not work on MSFS 2020")
+
+	for {
+		if err := runConnection(ctx); err != nil {
+			fmt.Printf("⚠️  %v\n", err)
+			return
+		}
+		fmt.Println("⏳ Waiting 5s before reconnecting...")
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(5 * time.Second):
+			fmt.Println("🔄 Reconnecting...")
+		}
+	}
+}

--- a/internal/simconnect/flow.go
+++ b/internal/simconnect/flow.go
@@ -1,0 +1,40 @@
+//go:build windows
+// +build windows
+
+package simconnect
+
+import "fmt"
+
+// SubscribeToFlowEvent subscribes to all simulator flow events. Whenever a flow
+// event fires, the dispatcher delivers a SIMCONNECT_RECV_FLOW_EVENT message.
+//
+// Note: MSFS 2024 only — returns an error on MSFS 2020.
+//
+// https://docs.flightsimulator.com/msfs2024/html/6_Programming_APIs/SimConnect/API_Reference/Events_And_Data/SimConnect_SubscribeToFlowEvent.htm
+func (sc *SimConnect) SubscribeToFlowEvent() error {
+	procedure := sc.library.LoadProcedure("SimConnect_SubscribeToFlowEvent")
+
+	hresult, _, _ := procedure.Call(sc.getConnection())
+
+	if !isHRESULTSuccess(hresult) {
+		return fmt.Errorf("SimConnect_SubscribeToFlowEvent failed with HRESULT: 0x%08X", uint32(hresult))
+	}
+	return nil
+}
+
+// UnsubscribeFromFlowEvent cancels the active flow event subscription.
+// After this call the dispatcher will no longer deliver SIMCONNECT_RECV_FLOW_EVENT messages.
+//
+// Note: MSFS 2024 only — returns an error on MSFS 2020.
+//
+// https://docs.flightsimulator.com/msfs2024/html/6_Programming_APIs/SimConnect/API_Reference/Events_And_Data/SimConnect_UnsubscribeToFlowEvent.htm
+func (sc *SimConnect) UnsubscribeFromFlowEvent() error {
+	procedure := sc.library.LoadProcedure("SimConnect_UnsubscribeToFlowEvent")
+
+	hresult, _, _ := procedure.Call(sc.getConnection())
+
+	if !isHRESULTSuccess(hresult) {
+		return fmt.Errorf("SimConnect_UnsubscribeToFlowEvent failed with HRESULT: 0x%08X", uint32(hresult))
+	}
+	return nil
+}

--- a/internal/simconnect/main.go
+++ b/internal/simconnect/main.go
@@ -35,6 +35,9 @@ type API interface {
 	UnsubscribeFromSystemEvent(eventID uint32) error
 	SetSystemEventState(eventID uint32, state types.SIMCONNECT_STATE) error
 
+	SubscribeToFlowEvent() error
+	UnsubscribeFromFlowEvent() error
+
 	FlightLoad(flightFile string) error
 	FlightPlanLoad(flightPlanFile string) error
 	FlightSave(flightFile string, title string, description string) error

--- a/pkg/engine/client.go
+++ b/pkg/engine/client.go
@@ -22,6 +22,11 @@ type Client interface {
 	SubscribeToSystemEvent(eventID uint32, eventName string) error
 	UnsubscribeFromSystemEvent(eventID uint32) error
 
+	// SubscribeToFlowEvent subscribes to all simulator flow events (MSFS 2024 only).
+	SubscribeToFlowEvent() error
+	// UnsubscribeFromFlowEvent cancels the active flow event subscription (MSFS 2024 only).
+	UnsubscribeFromFlowEvent() error
+
 	AddToDataDefinition(definitionID uint32, datumName string, unitsName string, datumType types.SIMCONNECT_DATATYPE, epsilon float32, datumID uint32) error
 	RequestDataOnSimObject(requestID uint32, definitionID uint32, objectID uint32, period types.SIMCONNECT_PERIOD, flags types.SIMCONNECT_DATA_REQUEST_FLAG, origin uint32, interval uint32, limit uint32) error
 	RequestDataOnSimObjectType(requestID uint32, definitionID uint32, dwRadiusMeters uint32, objectType types.SIMCONNECT_SIMOBJECT_TYPE) error

--- a/pkg/engine/flow.go
+++ b/pkg/engine/flow.go
@@ -1,0 +1,19 @@
+//go:build windows
+// +build windows
+
+package engine
+
+// SubscribeToFlowEvent subscribes to all simulator flow events.
+// Once subscribed, SIMCONNECT_RECV_FLOW_EVENT messages are delivered via Stream().
+//
+// Note: MSFS 2024 only — returns an error on MSFS 2020.
+func (e *Engine) SubscribeToFlowEvent() error {
+	return e.api.SubscribeToFlowEvent()
+}
+
+// UnsubscribeFromFlowEvent cancels the active flow event subscription.
+//
+// Note: MSFS 2024 only — returns an error on MSFS 2020.
+func (e *Engine) UnsubscribeFromFlowEvent() error {
+	return e.api.UnsubscribeFromFlowEvent()
+}

--- a/pkg/engine/message.go
+++ b/pkg/engine/message.go
@@ -222,3 +222,13 @@ func (m *Message) AsException() *types.SIMCONNECT_RECV_EXCEPTION {
 	}
 	return (*types.SIMCONNECT_RECV_EXCEPTION)(unsafe.Pointer(m.SIMCONNECT_RECV))
 }
+
+// AsFlowEvent casts the message to SIMCONNECT_RECV_FLOW_EVENT.
+// Returns nil if the message is not a flow event.
+// Note: MSFS 2024 only.
+func (m *Message) AsFlowEvent() *types.SIMCONNECT_RECV_FLOW_EVENT {
+	if types.SIMCONNECT_RECV_ID(m.DwID) != types.SIMCONNECT_RECV_ID_FLOW_EVENT {
+		return nil
+	}
+	return (*types.SIMCONNECT_RECV_FLOW_EVENT)(unsafe.Pointer(m.SIMCONNECT_RECV))
+}

--- a/pkg/manager/flight.go
+++ b/pkg/manager/flight.go
@@ -1,0 +1,37 @@
+//go:build windows
+// +build windows
+
+package manager
+
+// FlightLoad requests the simulator to load the flight file at the given path.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) FlightLoad(flightFile string) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.FlightLoad(flightFile)
+}
+
+// FlightPlanLoad requests the simulator to load the flight plan at the given path.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) FlightPlanLoad(flightPlanFile string) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.FlightPlanLoad(flightPlanFile)
+}
+
+// FlightSave requests the simulator to save the current flight to the given path.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) FlightSave(flightFile string, title string, description string) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.FlightSave(flightFile, title, description)
+}

--- a/pkg/manager/flow.go
+++ b/pkg/manager/flow.go
@@ -1,0 +1,37 @@
+//go:build windows
+// +build windows
+
+package manager
+
+// SubscribeToFlowEvent subscribes to all simulator flow events.
+// Once subscribed, SIMCONNECT_RECV_FLOW_EVENT messages are delivered to
+// all active message subscriptions and OnMessage handlers.
+//
+// Important: there is no automatic re-subscription on reconnect — it is the
+// caller's responsibility to call SubscribeToFlowEvent again after a
+// reconnection event if persistent flow event delivery is required.
+//
+// Note: MSFS 2024 only — returns an error on MSFS 2020.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) SubscribeToFlowEvent() error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.SubscribeToFlowEvent()
+}
+
+// UnsubscribeFromFlowEvent cancels the active flow event subscription.
+// After this call, SIMCONNECT_RECV_FLOW_EVENT messages will no longer be delivered.
+//
+// Note: MSFS 2024 only — returns an error on MSFS 2020.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) UnsubscribeFromFlowEvent() error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.engine.UnsubscribeFromFlowEvent()
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -308,6 +308,31 @@ type Manager interface {
 	// Returns ErrNotConnected if not connected to the simulator.
 	UnsubscribeFromSystemEvent(eventID uint32) error
 
+	// Flow Event Methods (MSFS 2024 only)
+
+	// SubscribeToFlowEvent subscribes to all simulator flow events.
+	// No automatic re-subscription on reconnect — caller responsibility.
+	// Returns ErrNotConnected if not connected to the simulator.
+	SubscribeToFlowEvent() error
+
+	// UnsubscribeFromFlowEvent cancels the active flow event subscription.
+	// Returns ErrNotConnected if not connected to the simulator.
+	UnsubscribeFromFlowEvent() error
+
+	// Flight Methods
+
+	// FlightLoad requests the simulator to load a saved flight file.
+	// Returns ErrNotConnected if not connected to the simulator.
+	FlightLoad(flightFile string) error
+
+	// FlightPlanLoad requests the simulator to load a flight plan file.
+	// Returns ErrNotConnected if not connected to the simulator.
+	FlightPlanLoad(flightPlanFile string) error
+
+	// FlightSave requests the simulator to save the current flight to a file.
+	// Returns ErrNotConnected if not connected to the simulator.
+	FlightSave(flightFile string, title string, description string) error
+
 	// Facility Methods
 	// These methods provide direct access to facility operations without needing
 	// to call Client() first. They return ErrNotConnected if not connected.

--- a/pkg/types/flow.go
+++ b/pkg/types/flow.go
@@ -1,0 +1,87 @@
+//go:build windows
+// +build windows
+
+package types
+
+import "fmt"
+
+// SIMCONNECT_FLOW_EVENT identifies the category of simulator flow event delivered
+// in a SIMCONNECT_RECV_FLOW_EVENT message.
+//
+// https://docs.flightsimulator.com/msfs2024/html/6_Programming_APIs/SimConnect/API_Reference/Structures_And_Enumerations/SIMCONNECT_FLOW_EVENT.htm
+type SIMCONNECT_FLOW_EVENT DWORD
+
+const (
+	SIMCONNECT_FLOW_EVENT_NONE              SIMCONNECT_FLOW_EVENT = iota // Should never be received.
+	SIMCONNECT_FLOW_EVENT_FLT_LOAD                                       // A .flt file is about to be loaded.
+	SIMCONNECT_FLOW_EVENT_FLT_LOADED                                     // A .flt file has been loaded; aircraft is in its new state.
+	SIMCONNECT_FLOW_EVENT_TELEPORT_START                                 // A teleport action is about to execute.
+	SIMCONNECT_FLOW_EVENT_TELEPORT_DONE                                  // A teleport action has completed.
+	SIMCONNECT_FLOW_EVENT_BACK_ON_TRACK_START                            // A back-on-track operation is about to execute.
+	SIMCONNECT_FLOW_EVENT_BACK_ON_TRACK_DONE                             // A back-on-track operation has completed.
+	SIMCONNECT_FLOW_EVENT_SKIP_START                                     // An activity section is about to be skipped.
+	SIMCONNECT_FLOW_EVENT_SKIP_DONE                                      // An activity section has been skipped.
+	SIMCONNECT_FLOW_EVENT_BACK_TO_MAIN_MENU                              // The simulator is returning to the main menu.
+	SIMCONNECT_FLOW_EVENT_RTC_START                                      // A real-time challenge has started.
+	SIMCONNECT_FLOW_EVENT_RTC_END                                        // A real-time challenge has ended.
+	SIMCONNECT_FLOW_EVENT_REPLAY_START                                   // A replay has started.
+	SIMCONNECT_FLOW_EVENT_REPLAY_END                                     // A replay has ended.
+	SIMCONNECT_FLOW_EVENT_FLIGHT_START                                   // A flight session has started.
+	SIMCONNECT_FLOW_EVENT_FLIGHT_END                                     // A flight session has ended.
+	SIMCONNECT_FLOW_EVENT_PLANE_CRASH                                    // An aircraft has crashed.
+)
+
+// String returns the human-readable name of the flow event.
+func (e SIMCONNECT_FLOW_EVENT) String() string {
+	switch e {
+	case SIMCONNECT_FLOW_EVENT_NONE:
+		return "NONE"
+	case SIMCONNECT_FLOW_EVENT_FLT_LOAD:
+		return "FLT_LOAD"
+	case SIMCONNECT_FLOW_EVENT_FLT_LOADED:
+		return "FLT_LOADED"
+	case SIMCONNECT_FLOW_EVENT_TELEPORT_START:
+		return "TELEPORT_START"
+	case SIMCONNECT_FLOW_EVENT_TELEPORT_DONE:
+		return "TELEPORT_DONE"
+	case SIMCONNECT_FLOW_EVENT_BACK_ON_TRACK_START:
+		return "BACK_ON_TRACK_START"
+	case SIMCONNECT_FLOW_EVENT_BACK_ON_TRACK_DONE:
+		return "BACK_ON_TRACK_DONE"
+	case SIMCONNECT_FLOW_EVENT_SKIP_START:
+		return "SKIP_START"
+	case SIMCONNECT_FLOW_EVENT_SKIP_DONE:
+		return "SKIP_DONE"
+	case SIMCONNECT_FLOW_EVENT_BACK_TO_MAIN_MENU:
+		return "BACK_TO_MAIN_MENU"
+	case SIMCONNECT_FLOW_EVENT_RTC_START:
+		return "RTC_START"
+	case SIMCONNECT_FLOW_EVENT_RTC_END:
+		return "RTC_END"
+	case SIMCONNECT_FLOW_EVENT_REPLAY_START:
+		return "REPLAY_START"
+	case SIMCONNECT_FLOW_EVENT_REPLAY_END:
+		return "REPLAY_END"
+	case SIMCONNECT_FLOW_EVENT_FLIGHT_START:
+		return "FLIGHT_START"
+	case SIMCONNECT_FLOW_EVENT_FLIGHT_END:
+		return "FLIGHT_END"
+	case SIMCONNECT_FLOW_EVENT_PLANE_CRASH:
+		return "PLANE_CRASH"
+	default:
+		return fmt.Sprintf("SIMCONNECT_FLOW_EVENT(%d)", uint32(e))
+	}
+}
+
+// SIMCONNECT_RECV_FLOW_EVENT is delivered when a simulator flow event fires and the
+// client has called SimConnect_SubscribeToFlowEvent. It reports which event occurred
+// and the virtual file system path of the .flt file currently loaded (if any).
+//
+// Note: MSFS 2024 only — SimConnect_SubscribeToFlowEvent is not available in MSFS 2020.
+//
+// https://docs.flightsimulator.com/msfs2024/html/6_Programming_APIs/SimConnect/API_Reference/Structures_And_Enumerations/SIMCONNECT_RECV_FLOW_EVENT.htm
+type SIMCONNECT_RECV_FLOW_EVENT struct {
+	SIMCONNECT_RECV                  // Base header: DwSize, DwVersion, DwID.
+	FlowEvent      SIMCONNECT_FLOW_EVENT // Category of the flow event.
+	FltPath        [256]byte             // VFS path of the currently loaded .flt file (null-terminated). Empty when not applicable.
+}


### PR DESCRIPTION
## Summary

- **#59** — `pkg/manager/flight.go`: `FlightLoad`, `FlightPlanLoad`, `FlightSave` delegation methods with `ErrNotConnected` guard; added to `Manager` interface.
- **#63** — Spike complete: `SimConnect_SubscribeToFlowEvent` / `SimConnect_UnsubscribeToFlowEvent` both take only `hSimConnect` — no event ID or event name. Global subscription model (one call covers all flow event categories). Findings posted to #63. Issues #64/#65 had incorrect signatures; corrected in implementation.
- **#64** — `internal/simconnect/flow.go` + `pkg/engine/flow.go`: DLL bindings and engine wrappers. `engine.Client` interface extended with `SubscribeToFlowEvent()` and `UnsubscribeFromFlowEvent()`. `msg.AsFlowEvent()` added to `engine.Message`.
- **#65** — `pkg/manager/flow.go`: manager delegation with `ErrNotConnected` guard. No auto-resubscription on reconnect documented. MSFS 2024-only limitation noted. Methods added to `Manager` interface.
- **#66** — `examples/flow-events/main.go`: connect → subscribe → receive and print flow events → unsubscribe on shutdown. MSFS 2024 requirement documented prominently.
- **bonus** — `.gitignore`: exclude runtime example output (`*.gpx`, `*.csv`, `*.json`).

## New types

```go
// pkg/types/flow.go
type SIMCONNECT_FLOW_EVENT DWORD          // 17 named constants + String()
type SIMCONNECT_RECV_FLOW_EVENT struct {
    SIMCONNECT_RECV
    FlowEvent SIMCONNECT_FLOW_EVENT
    FltPath   [256]byte
}
```

## Test plan

- [ ] `go build ./...` — passes
- [ ] `go vet -unsafeptr=false ./...` — passes
- [ ] `engine.Client` interface: `SubscribeToFlowEvent()` and `UnsubscribeFromFlowEvent()` present
- [ ] `Manager` interface: `SubscribeToFlowEvent()`, `UnsubscribeFromFlowEvent()`, `FlightLoad()`, `FlightPlanLoad()`, `FlightSave()` present
- [ ] Connect to MSFS 2024; run `flow-events` example; confirm `🌊 Flow event:` lines appear on teleport / flight load / flight start
- [ ] Confirm graceful unsubscribe and disconnect on Ctrl+C

Closes #59
Closes #63
Closes #64
Closes #65
Closes #66