### PR TITLE
feat(community): add sponsorship funding — FUNDING.yml, README, and website CTA

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# GitHub Sponsors funding configuration
+custom:
+  - "https://revolut.me/mrlm"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Sponsorship infrastructure** — `.github/FUNDING.yml` activates the GitHub Sponsor button (Revolut custom URL); `README.md` gains a `## Sponsoring` section listing what sponsorship covers; the marketing homepage gains a full-width CTA section. No Go code or API changes. Closes #172, #173, #174.
+
+---
+
 ## [0.3.6] - 2026-02-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ _Contributions are welcomed and must follow the [Code of Conduct](https://github
 
 > If you'd like to report a security issue please follow the [security guidelines](https://github.com/mrlm-net/simconnect?tab=security-ov-file).
 
+## Sponsoring
+
+This library is developed and maintained in personal time. Sponsorship helps cover the direct costs of keeping it accurate and active:
+
+- **MSFS 2024 license** — required to test against the current simulator version
+- **Windows development environment** — the only supported platform; ongoing hardware and OS costs
+- **Documentation hosting** — simconnect.mrlm.net is served from a paid static hosting account
+- **Development time** — research against undocumented SimConnect behaviors, writing typed wrappers, and reviewing contributions
+
+If this library has saved you time, a one-time or recurring contribution via [Revolut](https://revolut.me/mrlm) is appreciated. There is no obligation.
+
 ## License
 
 This project is licensed under the terms specified in the [LICENSE](LICENSE) file.

--- a/website/src/routes/(marketing)/+page.svelte
+++ b/website/src/routes/(marketing)/+page.svelte
@@ -333,6 +333,41 @@ func main() {
 	</div>
 </section>
 
+<!-- Sponsoring -->
+<section class="relative py-20" aria-labelledby="sponsoring-heading">
+	<div class="absolute inset-x-0 top-0 h-px" style="background: linear-gradient(90deg, transparent, var(--color-border) 20%, var(--color-border) 80%, transparent);"></div>
+	<div
+		class="pointer-events-none absolute inset-0"
+		style="background: radial-gradient(ellipse 60% 80% at 50% 50%, rgba(88,166,255,0.05) 0%, transparent 70%);"
+	></div>
+	<div class="relative mx-auto max-w-xl px-6 text-center">
+		<h2
+			id="sponsoring-heading"
+			class="mb-3 text-sm font-semibold uppercase tracking-widest"
+			style="color: var(--color-text-muted);"
+		>
+			Support the project
+		</h2>
+		<p class="mb-4 text-2xl font-bold tracking-tight" style="color: var(--color-text-primary);">
+			Back open-source MSFS tooling
+		</p>
+		<p class="mx-auto mb-8 max-w-md text-base leading-relaxed text-pretty" style="color: var(--color-text-secondary);">
+			Sponsoring covers infrastructure costs, development time, and MSFS&nbsp;2020&nbsp;&amp;&nbsp;2024
+			licences required to test against real simulator versions.
+		</p>
+		<a
+			href="https://revolut.me/mrlm"
+			target="_blank"
+			rel="noopener noreferrer"
+			class="inline-flex items-center gap-2 rounded-lg px-5 py-2.5 text-sm font-semibold shadow-sm transition-colors hover:brightness-110"
+			style="background-color: var(--color-link); color: var(--color-bg-primary);"
+		>
+			Sponsor via Revolut
+			<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+		</a>
+	</div>
+</section>
+
 <!-- Quick Links -->
 <section class="py-20 overflow-hidden" aria-labelledby="quick-links-heading">
 	<div class="mx-auto max-w-4xl px-6">


### PR DESCRIPTION
## Summary

- **`.github/FUNDING.yml`** (new) — activates GitHub Sponsor button on the repository page; configured with Revolut custom funding URL (`https://revolut.me/mrlm`)
- **`README.md`** (modified) — inserts a `## Sponsoring` section between `## Contributing` and `## License`, listing cost items covered by sponsorship and linking to Revolut
- **`website/src/routes/(marketing)/+page.svelte`** (modified) — inserts a full-width CTA section before `<!-- Quick Links -->` on the marketing homepage; markup-only, no changes to `<script>` or `<style>` blocks

## Quality gates

- Consistency gate (3/3): `revolut.me/mrlm` present in all three files
- `go build ./...` — clean
- `go vet -unsafeptr=false ./...` — clean

## Closes

Closes #172
Closes #173
Closes #174