### PR TITLE
feat(datasets): add Clone, Merge, and fluent Builder for composition

### DIFF
--- a/pkg/datasets/builder.go
+++ b/pkg/datasets/builder.go
@@ -1,0 +1,73 @@
+//go:build windows
+// +build windows
+
+package datasets
+
+import "github.com/mrlm-net/simconnect/pkg/types"
+
+// Builder provides a fluent API for constructing DataSet values incrementally.
+// All mutating methods return the receiver to allow method chaining.
+// Build() is non-destructive and may be called multiple times; each call
+// returns an independent snapshot of the current builder state.
+type Builder struct {
+	definitions []DataDefinition
+}
+
+// NewBuilder returns an empty Builder ready for use.
+func NewBuilder() *Builder {
+	return &Builder{}
+}
+
+// Add appends a DataDefinition to the builder.
+// Returns the builder for chaining.
+func (b *Builder) Add(def DataDefinition) *Builder {
+	b.definitions = append(b.definitions, def)
+	return b
+}
+
+// AddField appends a field specified by individual parameters.
+// Returns the builder for chaining.
+func (b *Builder) AddField(name, unit string, dataType types.SIMCONNECT_DATATYPE, epsilon float32) *Builder {
+	return b.Add(DataDefinition{
+		Name:    name,
+		Unit:    unit,
+		Type:    dataType,
+		Epsilon: epsilon,
+	})
+}
+
+// Remove removes the first definition with the given Name.
+// If no definition with that Name exists, Remove is a no-op.
+// Returns the builder for chaining.
+func (b *Builder) Remove(name string) *Builder {
+	for i, def := range b.definitions {
+		if def.Name == name {
+			b.definitions = append(b.definitions[:i], b.definitions[i+1:]...)
+			return b
+		}
+	}
+	return b
+}
+
+// Build returns a new DataSet snapshot of the current builder state.
+// The operation is repeatable: calling Build() multiple times produces
+// independent copies; adding to or removing from the builder after a Build()
+// call does not affect previously built DataSets.
+func (b *Builder) Build() DataSet {
+	// Use append into an empty slice to guarantee an independent backing array,
+	// preventing slice aliasing between the builder and the returned DataSet.
+	defs := append([]DataDefinition{}, b.definitions...)
+	return DataSet{Definitions: defs}
+}
+
+// Len returns the number of definitions currently held in the builder.
+func (b *Builder) Len() int {
+	return len(b.definitions)
+}
+
+// Reset removes all definitions from the builder.
+// Returns the builder for chaining.
+func (b *Builder) Reset() *Builder {
+	b.definitions = b.definitions[:0]
+	return b
+}

--- a/pkg/datasets/builder.go
+++ b/pkg/datasets/builder.go
@@ -68,6 +68,6 @@ func (b *Builder) Len() int {
 // Reset removes all definitions from the builder.
 // Returns the builder for chaining.
 func (b *Builder) Reset() *Builder {
-	b.definitions = b.definitions[:0]
+	b.definitions = nil
 	return b
 }

--- a/pkg/datasets/builder_test.go
+++ b/pkg/datasets/builder_test.go
@@ -1,0 +1,153 @@
+//go:build windows
+// +build windows
+
+package datasets
+
+import (
+	"testing"
+
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+func TestBuilder_EmptyBuild(t *testing.T) {
+	b := NewBuilder()
+	ds := b.Build()
+	if len(ds.Definitions) != 0 {
+		t.Fatalf("empty builder Build(): expected 0 definitions, got %d", len(ds.Definitions))
+	}
+}
+
+func TestBuilder_Add_FluentChaining(t *testing.T) {
+	b := NewBuilder().
+		Add(def("A")).
+		Add(def("B")).
+		Add(def("C"))
+
+	ds := b.Build()
+	got := names(ds)
+	want := []string{"A", "B", "C"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("Add chaining: got %v, want %v", got, want)
+	}
+}
+
+func TestBuilder_AddField_FluentChaining(t *testing.T) {
+	b := NewBuilder().
+		AddField("Altitude", "feet", types.SIMCONNECT_DATATYPE_FLOAT64, 0.5).
+		AddField("Speed", "knots", types.SIMCONNECT_DATATYPE_FLOAT32, 0)
+
+	if b.Len() != 2 {
+		t.Fatalf("AddField: expected Len 2, got %d", b.Len())
+	}
+
+	ds := b.Build()
+	if ds.Definitions[0].Name != "Altitude" {
+		t.Fatalf("AddField[0] name: got %q, want %q", ds.Definitions[0].Name, "Altitude")
+	}
+	if ds.Definitions[0].Epsilon != 0.5 {
+		t.Fatalf("AddField[0] epsilon: got %v, want 0.5", ds.Definitions[0].Epsilon)
+	}
+	if ds.Definitions[1].Name != "Speed" {
+		t.Fatalf("AddField[1] name: got %q, want %q", ds.Definitions[1].Name, "Speed")
+	}
+}
+
+func TestBuilder_Remove_Existing(t *testing.T) {
+	b := NewBuilder().Add(def("A")).Add(def("B")).Add(def("C"))
+	b.Remove("B")
+
+	got := names(b.Build())
+	want := []string{"A", "C"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("Remove existing: got %v, want %v", got, want)
+	}
+}
+
+func TestBuilder_Remove_NonExistent_IsNoop(t *testing.T) {
+	b := NewBuilder().Add(def("A")).Add(def("B"))
+	b.Remove("Z") // not present
+
+	got := names(b.Build())
+	want := []string{"A", "B"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("Remove non-existent: got %v, want %v", got, want)
+	}
+}
+
+func TestBuilder_Remove_OnlyFirstOccurrence(t *testing.T) {
+	b := NewBuilder().Add(def("A")).Add(def("A")).Add(def("B"))
+	b.Remove("A")
+
+	got := names(b.Build())
+	want := []string{"A", "B"} // second A remains
+	if !equalStringSlices(got, want) {
+		t.Fatalf("Remove first occurrence: got %v, want %v", got, want)
+	}
+}
+
+func TestBuilder_Build_IsRepeatable(t *testing.T) {
+	b := NewBuilder().Add(def("X")).Add(def("Y"))
+	ds1 := b.Build()
+	ds2 := b.Build()
+
+	if !equalStringSlices(names(ds1), names(ds2)) {
+		t.Fatalf("Build() not repeatable: ds1=%v ds2=%v", names(ds1), names(ds2))
+	}
+
+	// Both must be independent of each other.
+	ds1.Definitions[0].Name = "mutated"
+	if ds2.Definitions[0].Name == "mutated" {
+		t.Fatalf("two Build() calls share the same backing array")
+	}
+}
+
+func TestBuilder_Build_AliasSafety(t *testing.T) {
+	b := NewBuilder().Add(def("A")).Add(def("B"))
+	ds := b.Build()
+
+	// Add more to the builder after building.
+	b.Add(def("C"))
+
+	// The previously built DataSet must be unaffected.
+	if len(ds.Definitions) != 2 {
+		t.Fatalf("prior Build() result affected by subsequent Add: got %d definitions", len(ds.Definitions))
+	}
+}
+
+func TestBuilder_Len(t *testing.T) {
+	b := NewBuilder()
+	if b.Len() != 0 {
+		t.Fatalf("Len on empty builder: got %d, want 0", b.Len())
+	}
+	b.Add(def("A")).Add(def("B"))
+	if b.Len() != 2 {
+		t.Fatalf("Len after two Adds: got %d, want 2", b.Len())
+	}
+	b.Remove("A")
+	if b.Len() != 1 {
+		t.Fatalf("Len after Remove: got %d, want 1", b.Len())
+	}
+}
+
+func TestBuilder_Reset(t *testing.T) {
+	b := NewBuilder().Add(def("A")).Add(def("B"))
+	b.Reset()
+
+	if b.Len() != 0 {
+		t.Fatalf("after Reset Len: got %d, want 0", b.Len())
+	}
+
+	ds := b.Build()
+	if len(ds.Definitions) != 0 {
+		t.Fatalf("Build after Reset: got %d definitions, want 0", len(ds.Definitions))
+	}
+}
+
+func TestBuilder_Reset_Chaining(t *testing.T) {
+	b := NewBuilder().Add(def("A")).Reset().Add(def("B"))
+	got := names(b.Build())
+	want := []string{"B"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("Reset chaining: got %v, want %v", got, want)
+	}
+}

--- a/pkg/datasets/composition.go
+++ b/pkg/datasets/composition.go
@@ -1,0 +1,57 @@
+//go:build windows
+// +build windows
+
+package datasets
+
+// Merge combines multiple DataSets into one, deduplicating definitions by Name.
+//
+// Deduplication uses last-wins semantics: when the same Name appears more than
+// once across all input datasets, only the last encountered definition is kept,
+// and it occupies the position of that last occurrence (earlier duplicates are
+// removed, maintaining relative order of surviving entries).
+//
+// Example: Merge([A,B,C], [B,D]) produces [A,C,B,D]
+//   - B from the first dataset is removed because B reappears later.
+//   - The B from the second dataset occupies the position it was last seen.
+//
+// The returned DataSet is always a fresh independent copy; callers may mutate
+// it without affecting the input datasets.
+//
+// Special cases:
+//   - Merge() with zero arguments returns an empty DataSet.
+//   - Merge() with a single argument is equivalent to Clone.
+func Merge(datasets ...DataSet) DataSet {
+	if len(datasets) == 0 {
+		return DataSet{}
+	}
+
+	// order tracks the insertion order of surviving definitions. Because
+	// last-wins means we remove an earlier entry and re-insert at the end,
+	// we rebuild the ordered slice from the index map below.
+	//
+	// index maps each Name to its current position in 'order'.
+	order := make([]DataDefinition, 0)
+	index := make(map[string]int) // name → position in order
+
+	for _, ds := range datasets {
+		for _, def := range ds.Definitions {
+			if pos, exists := index[def.Name]; exists {
+				// Remove the previous occurrence by compacting the slice.
+				order = append(order[:pos], order[pos+1:]...)
+				// Shift all indices that were after the removed position.
+				for k, v := range index {
+					if v > pos {
+						index[k] = v - 1
+					}
+				}
+			}
+			// Append the new (or updated) definition at the end.
+			index[def.Name] = len(order)
+			order = append(order, def)
+		}
+	}
+
+	defs := make([]DataDefinition, len(order))
+	copy(defs, order)
+	return DataSet{Definitions: defs}
+}

--- a/pkg/datasets/composition_test.go
+++ b/pkg/datasets/composition_test.go
@@ -1,0 +1,145 @@
+//go:build windows
+// +build windows
+
+package datasets
+
+import (
+	"testing"
+
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+// helpers
+
+func def(name string) DataDefinition {
+	return DataDefinition{Name: name, Unit: "number", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0}
+}
+
+func names(ds DataSet) []string {
+	out := make([]string, len(ds.Definitions))
+	for i, d := range ds.Definitions {
+		out[i] = d.Name
+	}
+	return out
+}
+
+// Clone tests
+
+func TestClone_IndependentSlice(t *testing.T) {
+	original := DataSet{Definitions: []DataDefinition{def("A"), def("B")}}
+	clone := original.Clone()
+
+	// Appending to clone must not grow original.
+	clone.Definitions = append(clone.Definitions, def("C"))
+	if len(original.Definitions) != 2 {
+		t.Fatalf("append to clone grew original: got %d, want 2", len(original.Definitions))
+	}
+}
+
+func TestClone_IndependentFieldMutation(t *testing.T) {
+	original := DataSet{Definitions: []DataDefinition{def("A")}}
+	clone := original.Clone()
+
+	clone.Definitions[0].Name = "Z"
+	if original.Definitions[0].Name != "A" {
+		t.Fatalf("field mutation in clone affected original: got %q, want %q", original.Definitions[0].Name, "A")
+	}
+}
+
+func TestClone_EmptyDataSet(t *testing.T) {
+	original := DataSet{}
+	clone := original.Clone()
+	if clone.Definitions == nil {
+		// nil and empty are both acceptable; just verify length is 0.
+	}
+	if len(clone.Definitions) != 0 {
+		t.Fatalf("clone of empty dataset should have 0 definitions, got %d", len(clone.Definitions))
+	}
+}
+
+// Merge tests
+
+func TestMerge_ZeroArgs(t *testing.T) {
+	result := Merge()
+	if len(result.Definitions) != 0 {
+		t.Fatalf("Merge() with zero args: expected 0 definitions, got %d", len(result.Definitions))
+	}
+}
+
+func TestMerge_SingleArg_EquivalentToClone(t *testing.T) {
+	ds := DataSet{Definitions: []DataDefinition{def("A"), def("B"), def("C")}}
+	result := Merge(ds)
+
+	got := names(result)
+	want := []string{"A", "B", "C"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("Merge(single): got %v, want %v", got, want)
+	}
+
+	// Must be independent.
+	result.Definitions[0].Name = "Z"
+	if ds.Definitions[0].Name != "A" {
+		t.Fatalf("Merge(single) result shares backing array with input")
+	}
+}
+
+func TestMerge_Deduplication_LastWins(t *testing.T) {
+	// [A,B,C] + [B,D] → [A,C,B,D]
+	ds1 := DataSet{Definitions: []DataDefinition{def("A"), def("B"), def("C")}}
+	ds2 := DataSet{Definitions: []DataDefinition{def("B"), def("D")}}
+
+	result := Merge(ds1, ds2)
+	got := names(result)
+	want := []string{"A", "C", "B", "D"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("Merge dedup last-wins: got %v, want %v", got, want)
+	}
+}
+
+func TestMerge_NoOverlap_PreservesOrder(t *testing.T) {
+	ds1 := DataSet{Definitions: []DataDefinition{def("A"), def("B")}}
+	ds2 := DataSet{Definitions: []DataDefinition{def("C"), def("D")}}
+
+	result := Merge(ds1, ds2)
+	got := names(result)
+	want := []string{"A", "B", "C", "D"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("Merge no-overlap: got %v, want %v", got, want)
+	}
+}
+
+func TestMerge_TripleDuplicate(t *testing.T) {
+	// [A,B] + [B] + [B,C] → [A,B,C]  (last B at end)
+	ds1 := DataSet{Definitions: []DataDefinition{def("A"), def("B")}}
+	ds2 := DataSet{Definitions: []DataDefinition{def("B")}}
+	ds3 := DataSet{Definitions: []DataDefinition{def("B"), def("C")}}
+
+	result := Merge(ds1, ds2, ds3)
+	got := names(result)
+	want := []string{"A", "B", "C"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("Merge triple dup: got %v, want %v", got, want)
+	}
+}
+
+func TestMerge_ResultIsIndependent(t *testing.T) {
+	ds1 := DataSet{Definitions: []DataDefinition{def("A")}}
+	result := Merge(ds1)
+	result.Definitions[0].Name = "Z"
+	if ds1.Definitions[0].Name != "A" {
+		t.Fatalf("Merge result shares backing array with input")
+	}
+}
+
+// equalStringSlices is a simple helper; avoid importing reflect in tests.
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/datasets/dataset.go
+++ b/pkg/datasets/dataset.go
@@ -6,3 +6,12 @@ package datasets
 type DataSet struct {
 	Definitions []DataDefinition
 }
+
+// Clone returns an independent deep copy of the DataSet.
+// Mutations to the clone's Definitions slice (append or field mutation)
+// do not affect the original, and vice versa.
+func (ds DataSet) Clone() DataSet {
+	defs := make([]DataDefinition, len(ds.Definitions))
+	copy(defs, ds.Definitions)
+	return DataSet{Definitions: defs}
+}


### PR DESCRIPTION
## Summary

- Adds `Clone()` value-receiver method on `DataSet` for independent deep copy via `make`+`copy`
- Adds `Merge(...DataSet) DataSet` in `pkg/datasets/composition.go` with last-wins name deduplication and stable position shifting
- Adds `Builder` in `pkg/datasets/builder.go` with fluent `Add`, `AddField`, `Remove`, `Build`, `Len`, `Reset` methods; `Build()` uses `append([]DataDefinition{}, ...)` to prevent slice aliasing

## Test plan

- [x] `TestClone_IndependentSlice` — append to clone does not grow original
- [x] `TestClone_IndependentFieldMutation` — field mutation in clone does not affect original
- [x] `TestClone_EmptyDataSet` — clone of empty dataset returns empty
- [x] `TestMerge_ZeroArgs` — returns empty DataSet
- [x] `TestMerge_SingleArg_EquivalentToClone` — order preserved, independent copy
- [x] `TestMerge_Deduplication_LastWins` — `[A,B,C]+[B,D]` → `[A,C,B,D]`
- [x] `TestMerge_NoOverlap_PreservesOrder` — all fields in input order
- [x] `TestMerge_TripleDuplicate` — last of three duplicates survives
- [x] `TestMerge_ResultIsIndependent` — result does not alias input
- [x] `TestBuilder_EmptyBuild` — empty builder returns empty DataSet
- [x] `TestBuilder_Add_FluentChaining` — chained Add reflects correct order
- [x] `TestBuilder_AddField_FluentChaining` — field parameters stored correctly
- [x] `TestBuilder_Remove_Existing` — removes first match
- [x] `TestBuilder_Remove_NonExistent_IsNoop` — no-op when name absent
- [x] `TestBuilder_Remove_OnlyFirstOccurrence` — second duplicate preserved
- [x] `TestBuilder_Build_IsRepeatable` — two builds are equivalent and independent
- [x] `TestBuilder_Build_AliasSafety` — adding to builder after Build does not affect prior result
- [x] `TestBuilder_Len` — tracks count through Add/Remove
- [x] `TestBuilder_Reset` — clears builder; Build returns empty
- [x] `TestBuilder_Reset_Chaining` — Reset mid-chain works correctly

All 20 tests pass. `go build ./...` and `go vet -unsafeptr=false ./...` clean.

Closes #32