### PR TITLE
docs(datasets): add composition guide and update using-datasets example

### DIFF
--- a/docs/dataset-composition.md
+++ b/docs/dataset-composition.md
@@ -1,0 +1,313 @@
+---
+title: "Dataset Composition"
+description: "Clone, Merge, Builder, and Registry APIs for constructing and combining datasets."
+order: 5
+section: "datasets"
+---
+
+# Dataset Composition
+
+The `pkg/datasets` package provides four complementary APIs for constructing and combining datasets without touching raw `DataDefinition` slices directly: `Clone`, `Merge`, `Builder`, and the global `Registry`.
+
+## Clone
+
+`Clone` returns an independent deep copy of a `DataSet` value.
+
+```go
+import "github.com/mrlm-net/simconnect/pkg/datasets"
+
+original := datasets.DataSet{
+    Definitions: []datasets.DataDefinition{
+        {Name: "PLANE LATITUDE", Unit: "degrees", Type: types.SIMCONNECT_DATATYPE_FLOAT64},
+        {Name: "PLANE LONGITUDE", Unit: "degrees", Type: types.SIMCONNECT_DATATYPE_FLOAT64},
+    },
+}
+
+clone := original.Clone()
+```
+
+### Immutability contract
+
+`DataSet` is a value type — it holds a slice header, not a pointer. Assigning one `DataSet` to another copies the header (pointer, length, capacity) but not the backing array, so both variables still share the same underlying memory. `Clone` allocates a fresh backing array and copies all elements into it, breaking that shared reference.
+
+After `Clone`, appending to or modifying a field in `clone.Definitions` has no effect on `original`, and vice versa.
+
+### When to use Clone
+
+Use `Clone` when you need to hand a dataset to code that may mutate it (for example, passing it to a library that appends or reorders definitions) while keeping the source dataset unchanged. Also use it when storing a snapshot of a dataset for later comparison or rollback.
+
+Note: because `Clone` is a value receiver method, you can call it on any `DataSet` — including ones returned from constructor functions — without a pointer:
+
+```go
+ds := traffic.NewAircraftDataset()    // *DataSet
+snapshot := ds.Clone()                // independent copy
+```
+
+## Merge
+
+`Merge` combines any number of `DataSet` arguments into a single new `DataSet`, with last-wins deduplication by `Name`.
+
+```go
+merged := datasets.Merge(baseDS, extensionDS)
+```
+
+### Deduplication and position shift
+
+When the same `Name` appears in more than one input dataset, the earlier occurrence is removed and the later occurrence is placed at the position it was last seen. Relative order among surviving (non-duplicate) entries is preserved.
+
+Example:
+
+```
+Input A: [PLANE LATITUDE, PLANE LONGITUDE, PLANE ALTITUDE]
+Input B: [PLANE LONGITUDE, AIRSPEED INDICATED]
+
+Result:  [PLANE LATITUDE, PLANE ALTITUDE, PLANE LONGITUDE, AIRSPEED INDICATED]
+```
+
+`PLANE LONGITUDE` from `A` is removed because it reappears in `B`; the `B` copy occupies the position of its last occurrence (after `PLANE ALTITUDE`).
+
+### Zero and single argument behaviour
+
+- `Merge()` with zero arguments returns an empty `DataSet`.
+- `Merge(ds)` with a single argument is equivalent to `ds.Clone()` — it returns a fresh independent copy.
+
+### Independence guarantee
+
+The returned `DataSet` always owns its own backing array. Mutations to the result do not affect any of the input datasets.
+
+```go
+a := datasets.DataSet{Definitions: []datasets.DataDefinition{
+    {Name: "PLANE LATITUDE",  Unit: "degrees", Type: types.SIMCONNECT_DATATYPE_FLOAT64},
+    {Name: "PLANE LONGITUDE", Unit: "degrees", Type: types.SIMCONNECT_DATATYPE_FLOAT64},
+    {Name: "PLANE ALTITUDE",  Unit: "feet",    Type: types.SIMCONNECT_DATATYPE_FLOAT64},
+}}
+b := datasets.DataSet{Definitions: []datasets.DataDefinition{
+    {Name: "PLANE LONGITUDE",   Unit: "degrees", Type: types.SIMCONNECT_DATATYPE_FLOAT64},
+    {Name: "AIRSPEED INDICATED", Unit: "knots",  Type: types.SIMCONNECT_DATATYPE_FLOAT64},
+}}
+
+result := datasets.Merge(a, b)
+// result.Definitions: [PLANE LATITUDE, PLANE ALTITUDE, PLANE LONGITUDE, AIRSPEED INDICATED]
+```
+
+## Builder
+
+`Builder` provides a fluent API for constructing `DataSet` values incrementally. It is useful when you want to assemble a dataset programmatically or extend an existing one without mutating the source.
+
+```go
+import "github.com/mrlm-net/simconnect/pkg/datasets"
+import "github.com/mrlm-net/simconnect/pkg/types"
+
+ds := datasets.NewBuilder().
+    AddField("PLANE LATITUDE",  "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0).
+    AddField("PLANE LONGITUDE", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0).
+    AddField("PLANE ALTITUDE",  "feet",    types.SIMCONNECT_DATATYPE_FLOAT64, 0).
+    Build()
+```
+
+### AddField vs Add
+
+`AddField` is the convenience form — it takes individual parameters and constructs the `DataDefinition` internally:
+
+```go
+b.AddField("PLANE LATITUDE", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0)
+```
+
+`Add` accepts a pre-built `DataDefinition` and is useful when you already have a value or want to share a definition across multiple builders:
+
+```go
+latDef := datasets.DataDefinition{
+    Name: "PLANE LATITUDE", Unit: "degrees",
+    Type: types.SIMCONNECT_DATATYPE_FLOAT64,
+}
+b.Add(latDef)
+```
+
+Both methods return the receiver for chaining.
+
+### Remove
+
+`Remove` removes the first definition whose `Name` matches the argument. If no match is found, it is a no-op — it does not panic:
+
+```go
+b.Remove("PLANE ALTITUDE")     // removes if present, ignored if absent
+```
+
+### Repeatable Build
+
+`Build` is non-destructive. Each call takes an independent snapshot of the builder's current state, so you can call `Build` multiple times to produce independent datasets at different stages:
+
+```go
+b := datasets.NewBuilder().
+    AddField("PLANE LATITUDE", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0).
+    AddField("PLANE LONGITUDE", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0)
+
+posOnly := b.Build()    // [PLANE LATITUDE, PLANE LONGITUDE]
+
+b.AddField("PLANE ALTITUDE", "feet", types.SIMCONNECT_DATATYPE_FLOAT64, 0)
+withAlt := b.Build()    // [PLANE LATITUDE, PLANE LONGITUDE, PLANE ALTITUDE]
+
+// posOnly is unchanged — it still has only two fields
+```
+
+### Aliasing safety
+
+`Build` uses `append([]DataDefinition{}, b.definitions...)` internally, which always allocates a new backing array. The returned `DataSet` never shares memory with the builder or any previously built `DataSet`, so caller mutations are isolated.
+
+### Reset
+
+`Reset` removes all definitions from the builder and returns the receiver for chaining. Use it to reuse a builder across multiple construction cycles without allocating a new one:
+
+```go
+b := datasets.NewBuilder()
+
+b.AddField("PLANE LATITUDE", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0)
+snapshot1 := b.Build()
+
+b.Reset().
+    AddField("AIRSPEED INDICATED", "knots", types.SIMCONNECT_DATATYPE_FLOAT64, 0)
+snapshot2 := b.Build()
+// snapshot1 and snapshot2 are independent; snapshot1 is unaffected by Reset
+```
+
+### Len
+
+`Len` returns the number of definitions currently held in the builder. It is useful for guard checks before calling `Build`:
+
+```go
+if b.Len() == 0 {
+    return fmt.Errorf("dataset builder is empty")
+}
+ds := b.Build()
+```
+
+## Registry
+
+The global registry allows sub-packages to advertise named datasets via `init()` side-effects. Callers discover available datasets at runtime through the registry API.
+
+### Naming convention
+
+Dataset names follow the `"<category>/<descriptor>"` format, for example `"traffic/aircraft"`. The category groups related datasets and is used by `ListByCategory`. The name uniquely identifies a dataset across the entire process.
+
+### Registration via import side-effect
+
+Sub-packages call `datasets.Register` in their `init()` function. Importing the sub-package triggers `init()`, which registers the dataset. No explicit registration call is needed in application code:
+
+```go
+import (
+    "github.com/mrlm-net/simconnect/pkg/datasets"
+    _ "github.com/mrlm-net/simconnect/pkg/datasets/traffic"  // side-effect: registers "traffic/aircraft"
+)
+```
+
+The blank import `_` is the Go idiom for importing a package solely for its `init()` side-effects.
+
+### Get
+
+`Get` retrieves the constructor function for a named dataset. The constructor returns a fresh `*DataSet` on every call:
+
+```go
+ctor, ok := datasets.Get("traffic/aircraft")
+if !ok {
+    log.Fatal("traffic/aircraft not registered")
+}
+ds := ctor()   // fresh *DataSet
+```
+
+Always check `ok` before calling the constructor. A missing name returns `nil, false`.
+
+### List and Categories
+
+`List` returns the names of all registered datasets sorted alphabetically. `Categories` returns the distinct category names sorted alphabetically. Both are useful for introspection and tooling:
+
+```go
+fmt.Println("Registered datasets:", datasets.List())
+fmt.Println("Categories:", datasets.Categories())
+```
+
+### ListByCategory
+
+`ListByCategory` narrows the listing to a single category. Returns `nil` if no datasets are registered under that category:
+
+```go
+trafficDatasets := datasets.ListByCategory("traffic")
+for _, name := range trafficDatasets {
+    fmt.Println(name)
+}
+```
+
+### Concurrent safety
+
+All registry operations (`Register`, `Get`, `List`, `Categories`, `ListByCategory`) are safe for concurrent use. The registry uses a `sync.RWMutex` internally: reads (Get, List, Categories, ListByCategory) acquire a read lock; writes (Register) acquire an exclusive write lock.
+
+### Panics on empty name or category
+
+`Register` panics if either `name` or `category` is an empty string. This is an intentional fail-fast guard against misconfigured `init()` calls that would otherwise silently produce unqueryable entries:
+
+```go
+// panics: name must not be empty
+datasets.Register("", "traffic", constructor)
+
+// panics: category must not be empty
+datasets.Register("traffic/aircraft", "", constructor)
+```
+
+### Overwrite behaviour
+
+Registering the same name twice silently overwrites the previous entry. This allows test code and alternative implementations to replace a built-in dataset without ceremony.
+
+## End-to-end example
+
+The following snippet ties together all four APIs: import side-effect, registry discovery, `Clone`, `Builder`, and `Merge`.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+
+    "github.com/mrlm-net/simconnect/pkg/datasets"
+    _ "github.com/mrlm-net/simconnect/pkg/datasets/traffic" // registers "traffic/aircraft"
+    "github.com/mrlm-net/simconnect/pkg/types"
+)
+
+func main() {
+    // 1. Discover what is registered.
+    fmt.Println("Registered datasets:", datasets.List())
+    fmt.Println("Categories:", datasets.Categories())
+
+    // 2. Retrieve the traffic/aircraft constructor from the registry.
+    ctor, ok := datasets.Get("traffic/aircraft")
+    if !ok {
+        panic("traffic/aircraft not registered")
+    }
+    trafficDS := ctor() // fresh *DataSet from the constructor
+
+    // 3. Clone to get an independent copy before extending.
+    extended := trafficDS.Clone()
+
+    // 4. Build a minimal position dataset using the fluent builder.
+    posDS := datasets.NewBuilder().
+        AddField("PLANE LATITUDE",  "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0).
+        AddField("PLANE LONGITUDE", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0).
+        AddField("PLANE ALTITUDE",  "feet",    types.SIMCONNECT_DATATYPE_FLOAT64, 0).
+        Build()
+
+    // 5. Merge the cloned traffic dataset with the position dataset.
+    //    Duplicate names (PLANE LATITUDE, PLANE LONGITUDE, PLANE ALTITUDE)
+    //    are deduplicated with last-wins: the posDS versions replace the
+    //    traffic dataset's versions, shifting to the end.
+    merged := datasets.Merge(extended, posDS)
+
+    fmt.Printf("Traffic fields:  %d\n", len(trafficDS.Definitions))
+    fmt.Printf("Position fields: %d\n", len(posDS.Definitions))
+    fmt.Printf("Merged fields:   %d\n", len(merged.Definitions))
+}
+```
+
+## See Also
+
+- [Engine/Client Usage](usage-client.md) — `RegisterDataset` for submitting a dataset to SimConnect
+- [Manager Usage](usage-manager.md) — dataset registration in the managed connection lifecycle

--- a/docs/dataset-composition.md
+++ b/docs/dataset-composition.md
@@ -209,7 +209,7 @@ The blank import `_` is the Go idiom for importing a package solely for its `ini
 ```go
 ctor, ok := datasets.Get("traffic/aircraft")
 if !ok {
-    log.Fatal("traffic/aircraft not registered")
+    panic("traffic/aircraft not registered")
 }
 ds := ctor()   // fresh *DataSet
 ```

--- a/examples/using-datasets/main.go
+++ b/examples/using-datasets/main.go
@@ -1,291 +1,137 @@
 //go:build windows
 // +build windows
 
+// Package main demonstrates dataset composition and registry APIs.
+//
+// It shows how to:
+//   - Auto-register datasets via blank import side-effect
+//   - Discover registered datasets with List, Categories, and ListByCategory
+//   - Retrieve a dataset constructor from the registry with Get
+//   - Clone a dataset to produce an independent copy
+//   - Build a custom dataset with the fluent Builder
+//   - Merge datasets with last-wins deduplication
+//
+// The example connects to the simulator but does NOT request SimVar data.
+// Its purpose is to demonstrate the composition APIs clearly; the SimConnect
+// connection is included only to show that the merged dataset is ready for
+// use with RegisterDataset when a simulator session is available.
 package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/signal"
-	"path/filepath"
-	"time"
 
 	"github.com/mrlm-net/simconnect"
-	"github.com/mrlm-net/simconnect/pkg/datasets/traffic"
+	"github.com/mrlm-net/simconnect/pkg/datasets"
+	_ "github.com/mrlm-net/simconnect/pkg/datasets/traffic" // side-effect: registers "traffic/aircraft"
 	"github.com/mrlm-net/simconnect/pkg/engine"
 	"github.com/mrlm-net/simconnect/pkg/types"
 )
 
-var cwd, _ = os.Getwd()
-
-type ParkedAircraft struct {
-	Airport         string `json:"airport"`
-	Plane           string `json:"plane"`
-	FlightPlan      string `json:"plan,omitempty"`
-	FlightClearance int    `json:"clearance,omitempty"`
-	Number          string `json:"number"`
-}
-
-type IFRAircraft struct {
-	Plane      string  `json:"plane"`
-	Number     string  `json:"number"`
-	FlightPlan string  `json:"plan"`
-	InitPhase  float64 `json:"phase"`
-}
-
-type AircraftData traffic.AircraftDataset
-
-func (data *AircraftData) TitleAsString() string {
-	return engine.BytesToString(data.Title[:])
-}
-
-func (data *AircraftData) CategoryAsString() string {
-	return engine.BytesToString(data.Category[:])
-}
-
-func (data *AircraftData) LiveryNameAsString() string {
-	return engine.BytesToString(data.LiveryName[:])
-}
-
-func (data *AircraftData) LiveryFolderAsString() string {
-	return engine.BytesToString(data.LiveryFolder[:])
-}
-
-func (data *AircraftData) ATCIDAsString() string {
-	return engine.BytesToString(data.AtcID[:])
-}
-
-func (data *AircraftData) AtcAirlineAsString() string {
-	return engine.BytesToString(data.AtcAirline[:])
-}
-
-// runConnection handles a single connection lifecycle to the simulator.
-// Returns nil when the simulator disconnects (allowing reconnection),
-// or an error if cancelled via context.
-func runConnection(ctx context.Context) error {
-	// Initialize client with context
-	client := simconnect.NewClient("GO Example - SimConnect Read Messages and their data by using Datasets",
-		engine.WithContext(ctx),
-	)
-
-	// Retry connection until simulator is running
-	fmt.Println("⏳ Waiting for simulator to start...")
-	for {
-		select {
-		case <-ctx.Done():
-			fmt.Println("🛑 Cancelled while waiting for simulator")
-			return ctx.Err()
-		default:
-			if err := client.Connect(); err != nil {
-				fmt.Printf("🔄 Connection attempt failed: %v, retrying in 2 seconds...\n", err)
-				time.Sleep(2 * time.Second)
-				continue
-			}
-			goto connected
-		}
-	}
-
-connected:
-	fmt.Println("✅ Connected to SimConnect, listening for messages...")
-	// We can already register data definitions and requests here
-	addPlanesRequestDataset(client)
-	// Load parked aircraft from JSON
-	planes, err := loadParkedAircraft("planes.json")
-	if err != nil {
-		fmt.Println("Error:", err)
-		return err
-	}
-	// Add parked aircraft and set flight plans with delays if specified
-	for i, p := range planes {
-		//wg := &sync.WaitGroup{}
-
-		if p.FlightClearance >= 0 && p.FlightPlan != "" {
-			//wg.Add(1)
-			// Simple per-plane delay (tweak as needed or load from data):
-			delay := time.Duration(p.FlightClearance) * time.Second
-			time.AfterFunc(delay, func(p ParkedAircraft) func() {
-				return func() {
-					//defer wg.Done()
-					// Demo: assign a flight plan or any follow-up work here.
-					// Replace with real SimConnect call if desired.
-					fmt.Printf("📝 Assigning flight plan for %s (%s) after %s\n", p.Plane, p.Number, delay)
-					// Example placeholder: filepath.Join(cwd, "plans", p.FlightPlan)
-					client.AICreateEnrouteATCAircraftEX1(p.Plane, "", p.Number, 123+uint32(i),
-						filepath.Join(cwd, "plans", p.FlightPlan), 0.0, false, 2000+uint32(i))
-				}
-			}(p))
-		} else {
-			fmt.Printf("📝 Adding parked plane - plane=%s number=%s\n", p.Plane, p.Number)
-			client.AICreateParkedATCAircraft(p.Plane, p.Number, p.Airport, 1000+uint32(i))
-		}
-	}
-	fmt.Println("✈️  Ready for plane spotting???")
-
-	//client.AICreateParkedATCAircraft("FSLTL A320 VLG Vueling", "N12345", "LKPR", 5000)
-	//client.AICreateParkedATCAircraft("FSLTL_A359_CAL-China Airlines", "N12346", "LKPR", 5001)
-	// FSLTL A320 Air France SL
-
-	//client.FlightPlanLoad("C:\\MSFS-TEST-PLANS\\LKPRLKPD_M24_06Dec25")
-	//client.AICreateEnrouteATCAircraft("FSLTL A320 Air France SL", "N12347", 123, "C:\\MSFS-TEST-PLANS\\LKPREDDN_MFS_NoProc_07Dec25", 0.0, false, 5006)
-
-	// Request data for all aircraft within 50km radius
-	client.RequestDataOnSimObjectType(4001, 3000, 25000, types.SIMCONNECT_SIMOBJECT_TYPE_AIRCRAFT)
-
-	// create ticker to periodically request data
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				client.RequestDataOnSimObjectType(4001, 3000, 25000, types.SIMCONNECT_SIMOBJECT_TYPE_AIRCRAFT)
-			}
-		}
-	}()
-
-	// Wait for SIMCONNECT_RECV_ID_OPEN message to confirm connection is ready
-	stream := client.Stream()
-	// Main message processing loop
-	for {
-		select {
-		case <-ctx.Done():
-			fmt.Println("🔌 Context cancelled, disconnecting...")
-			if err := client.Disconnect(); err != nil {
-				fmt.Fprintf(os.Stderr, "❌ Disconnect error: %v\n", err)
-			}
-			//fmt.Println("Disconnected from SimConnect")
-			return ctx.Err()
-		case msg, ok := <-stream:
-			if !ok {
-				fmt.Println("📴 Stream closed (simulator disconnected)")
-				return nil // Return nil to allow reconnection
-			}
-
-			if msg.Err != nil {
-				fmt.Fprintf(os.Stderr, "❌ Error: %v\n", msg.Err)
-				continue
-			}
-
-			fmt.Println("📨 Message received - ", types.SIMCONNECT_RECV_ID(msg.SIMCONNECT_RECV.DwID))
-
-			// Handle specific messages
-			// This could be done based on type and also if needed request IDs
-			switch types.SIMCONNECT_RECV_ID(msg.DwID) {
-			case types.SIMCONNECT_RECV_ID_OPEN:
-				fmt.Println("🟢 Connection ready (SIMCONNECT_RECV_ID_OPEN received)")
-				msg := msg.AsOpen()
-				fmt.Println("📡 Received SIMCONNECT_RECV_OPEN message!")
-				fmt.Printf("  Application Name: '%s'\n", engine.BytesToString(msg.SzApplicationName[:]))
-				fmt.Printf("  Application Version: %d.%d\n", msg.DwApplicationVersionMajor, msg.DwApplicationVersionMinor)
-				fmt.Printf("  Application Build: %d.%d\n", msg.DwApplicationBuildMajor, msg.DwApplicationBuildMinor)
-				fmt.Printf("  SimConnect Version: %d.%d\n", msg.DwSimConnectVersionMajor, msg.DwSimConnectVersionMinor)
-				fmt.Printf("  SimConnect Build: %d.%d\n", msg.DwSimConnectBuildMajor, msg.DwSimConnectBuildMinor)
-			case types.SIMCONNECT_RECV_ID_SIMOBJECT_DATA_BYTYPE:
-				simObjData := msg.AsSimObjectDataBType()
-				fmt.Printf("     Request ID: %d, Define ID: %d, Object ID: %d, Flags: %d, Out of: %d, DefineCount: %d\n",
-					simObjData.DwRequestID,
-					simObjData.DwDefineID,
-					simObjData.DwObjectID,
-					simObjData.DwFlags,
-					simObjData.DwOutOf,
-					simObjData.DwDefineCount,
-				)
-				if simObjData.DwDefineID == 3000 {
-					aircraftData := engine.CastDataAs[AircraftData](&simObjData.DwData)
-					// Verbose whole data dump
-					//fmt.Printf("     Aircraft Data: %+v\n", aircraftData)
-					// Print selected fields
-					fmt.Printf("     Aircraft Title: %s, Category: %s, Livery Name: %s, Livery Folder: %s, Lat: %f, Lon: %f, Alt: %f, Head: %f, HeadMag: %f, VS: %f, Pitch: %f, Bank: %f, GroundSpeed: %f, AirspeedIndicated: %f, AirspeedTrue: %f, OnAnyRunway: %d, SurfaceType: %d, SimOnGround: %d, AtcID: %s, AtcAirline: %s, AmbientInCloud: %d, IsUserSim: %d, IsTowConnected: %d, AltAboveGround: %f, WingSpan: %f \n",
-						aircraftData.TitleAsString(),
-						aircraftData.CategoryAsString(),
-						aircraftData.LiveryNameAsString(),
-						aircraftData.LiveryFolderAsString(),
-						aircraftData.Lat,
-						aircraftData.Lon,
-						aircraftData.Alt,
-						aircraftData.Head,
-						aircraftData.HeadMag,
-						aircraftData.Vs,
-						aircraftData.Pitch,
-						aircraftData.Bank,
-						aircraftData.GroundSpeed,
-						aircraftData.AirspeedIndicated,
-						aircraftData.AirspeedTrue,
-						aircraftData.OnAnyRunway,
-						aircraftData.SurfaceType,
-						aircraftData.SimOnGround,
-						aircraftData.ATCIDAsString(),
-						aircraftData.AtcAirlineAsString(),
-						aircraftData.AmbientInCloud,
-						aircraftData.IsUserSim,
-						aircraftData.IsTowConnected,
-						aircraftData.AltAboveGround,
-						aircraftData.WingSpan,
-					)
-				}
-			default:
-				// Other message types can be handled here
-			}
-		}
-	}
-}
-
 func main() {
-	// Create cancellable context for graceful shutdown
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Setup signal handler for Ctrl+C
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt)
 	go func() {
 		<-sigChan
-		fmt.Println("🛑 Received interrupt signal, shutting down...")
+		fmt.Println("Received interrupt, shutting down...")
 		cancel()
 	}()
 
-	fmt.Println("ℹ️  (Press Ctrl+C to exit)")
+	// --- Registry discovery ---------------------------------------------------
+	// The blank import of the traffic package triggered its init(), which called
+	// datasets.Register("traffic/aircraft", "traffic", NewAircraftDataset).
+	// We can now discover it without knowing its name up front.
 
-	// Reconnection loop - keeps trying to connect when simulator disconnects
-	for {
-		err := runConnection(ctx)
-		if err != nil {
-			// Context cancelled (Ctrl+C) - exit completely
-			fmt.Printf("⚠️  Connection ended: %v\n", err)
-			return
-		}
+	fmt.Println("=== Registry ===")
+	fmt.Println("All registered datasets:", datasets.List())
+	fmt.Println("All categories:", datasets.Categories())
+	fmt.Println("Datasets in 'traffic' category:", datasets.ListByCategory("traffic"))
 
-		// Simulator disconnected (err == nil) - wait and retry
-		fmt.Println("⏳ Waiting 5 seconds before reconnecting...")
-		select {
-		case <-ctx.Done():
-			fmt.Println("🛑 Shutdown requested, not reconnecting")
-			return
-		case <-time.After(5 * time.Second):
-			fmt.Println("🔄 Attempting to reconnect...")
-		}
+	// --- Get: retrieve constructor from registry ------------------------------
+
+	ctor, ok := datasets.Get("traffic/aircraft")
+	if !ok {
+		fmt.Fprintln(os.Stderr, "ERROR: traffic/aircraft not found in registry")
+		os.Exit(1)
 	}
-}
-
-func loadParkedAircraft(path string) ([]ParkedAircraft, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("read file: %w", err)
+	trafficDS := ctor() // fresh *DataSet on every call
+	fmt.Printf("\n=== traffic/aircraft dataset (%d fields) ===\n", len(trafficDS.Definitions))
+	for i, def := range trafficDS.Definitions {
+		fmt.Printf("  [%2d] %-40s  unit=%-20s  type=%d\n", i, def.Name, def.Unit, def.Type)
 	}
 
-	var planes []ParkedAircraft
-	if err := json.Unmarshal(data, &planes); err != nil {
-		return nil, fmt.Errorf("unmarshal: %w", err)
-	}
-	return planes, nil
-}
+	// --- Clone ----------------------------------------------------------------
+	// Clone returns an independent deep copy.  Mutations to the clone do not
+	// affect trafficDS and vice versa.
 
-func addPlanesRequestDataset(client engine.Client) {
-	// Define data structure for plane request dataset
-	client.RegisterDataset(
-		3000, traffic.NewAircraftDataset(),
+	clonedDS := trafficDS.Clone()
+	fmt.Printf("\n=== Clone (%d fields, independent copy) ===\n", len(clonedDS.Definitions))
+
+	// --- Builder --------------------------------------------------------------
+	// Build a small supplementary dataset with fields not in the traffic set,
+	// plus one overlapping field (PLANE ALTITUDE) to show Merge deduplication.
+
+	supplementary := datasets.NewBuilder().
+		AddField("PLANE ALTITUDE", "feet", types.SIMCONNECT_DATATYPE_FLOAT64, 0.5).          // overlaps traffic
+		AddField("AMBIENT TEMPERATURE", "celsius", types.SIMCONNECT_DATATYPE_FLOAT64, 0).    // new
+		AddField("AMBIENT WIND VELOCITY", "knots", types.SIMCONNECT_DATATYPE_FLOAT64, 0).    // new
+		AddField("AMBIENT WIND DIRECTION", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0). // new
+		Build()
+
+	fmt.Printf("\n=== Supplementary dataset (Builder, %d fields) ===\n", len(supplementary.Definitions))
+	for i, def := range supplementary.Definitions {
+		fmt.Printf("  [%2d] %-40s  epsilon=%.1f\n", i, def.Name, def.Epsilon)
+	}
+
+	// Demonstrate repeatable Build and Remove.
+	b := datasets.NewBuilder().
+		AddField("PLANE LATITUDE", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0).
+		AddField("PLANE LONGITUDE", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0).
+		AddField("PLANE ALTITUDE", "feet", types.SIMCONNECT_DATATYPE_FLOAT64, 0)
+
+	posWithAlt := b.Build() // snapshot 1: three fields
+	b.Remove("PLANE ALTITUDE")
+	posOnly := b.Build() // snapshot 2: two fields (PLANE ALTITUDE removed)
+
+	fmt.Printf("\n=== Builder: posWithAlt=%d fields, posOnly=%d fields ===\n",
+		len(posWithAlt.Definitions), len(posOnly.Definitions))
+
+	// --- Merge ----------------------------------------------------------------
+	// Merge(clonedDS, supplementary) combines the two datasets with last-wins
+	// deduplication.  PLANE ALTITUDE appears in both; the supplementary version
+	// (epsilon=0.5) wins and shifts to its last-seen position.
+
+	merged := datasets.Merge(clonedDS, supplementary)
+	fmt.Printf("\n=== Merged dataset (%d fields) ===\n", len(merged.Definitions))
+	fmt.Printf("  traffic: %d + supplementary: %d - 1 duplicate = %d expected\n",
+		len(clonedDS.Definitions), len(supplementary.Definitions), len(merged.Definitions))
+	for i, def := range merged.Definitions {
+		fmt.Printf("  [%2d] %-40s  epsilon=%.1f\n", i, def.Name, def.Epsilon)
+	}
+
+	// --- Optional SimConnect registration ------------------------------------
+	// Connect to the simulator (if running) and register the merged dataset to
+	// show it is ready for real use.  The example exits immediately after
+	// printing the connection result — it does not enter a data request loop.
+
+	fmt.Println("\n=== SimConnect (optional) ===")
+	client := simconnect.NewClient("GO Example - Dataset Composition",
+		engine.WithContext(ctx),
 	)
+
+	if err := client.Connect(); err != nil {
+		fmt.Printf("Simulator not running (%v) — skipping registration demo\n", err)
+	} else {
+		const mergedDefID = 1000
+		client.RegisterDataset(mergedDefID, &merged)
+		fmt.Printf("Registered merged dataset under define ID %d\n", mergedDefID)
+		_ = client.Disconnect()
+	}
+
+	cancel()
+	fmt.Println("\nDone.")
 }

--- a/examples/using-datasets/main.go
+++ b/examples/using-datasets/main.go
@@ -127,8 +127,11 @@ func main() {
 		fmt.Printf("Simulator not running (%v) — skipping registration demo\n", err)
 	} else {
 		const mergedDefID = 1000
-		client.RegisterDataset(mergedDefID, &merged)
-		fmt.Printf("Registered merged dataset under define ID %d\n", mergedDefID)
+		if err := client.RegisterDataset(mergedDefID, &merged); err != nil {
+			fmt.Printf("RegisterDataset failed: %v\n", err)
+		} else {
+			fmt.Printf("Registered merged dataset under define ID %d\n", mergedDefID)
+		}
 		_ = client.Disconnect()
 	}
 


### PR DESCRIPTION
## Summary

- Creates `docs/dataset-composition.md` covering the Clone, Merge, Builder, and Registry APIs with inline code examples and an end-to-end snippet tying all four together
- Rewrites `examples/using-datasets/main.go` to demonstrate blank-import side-effect registration, `List`/`Categories`/`ListByCategory` discovery, `Get`, `Clone`, fluent `Builder` (including `Remove` and repeatable `Build`), and `Merge` with last-wins deduplication
- Example connects to SimConnect if the simulator is running to show `RegisterDataset` integration, but is fully runnable without a live sim session

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] `go vet -unsafeptr=false ./...` passes (verified locally)
- [ ] Doc sections: Clone, Merge, Builder, Registry each have code examples
- [ ] Example compiles and demonstrates all four composition APIs
- [ ] Merge deduplication output in example matches documented last-wins semantics

Closes #35