### PR TITLE
feat(traffic): add pkg/traffic package and manager integration

### DIFF
--- a/pkg/manager/instance.go
+++ b/pkg/manager/instance.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mrlm-net/simconnect/pkg/engine"
 	"github.com/mrlm-net/simconnect/pkg/manager/internal/instance"
+	"github.com/mrlm-net/simconnect/pkg/traffic"
 	"github.com/mrlm-net/simconnect/pkg/types"
 )
 
@@ -111,6 +112,10 @@ type Instance struct {
 
 	// Current engine instance (recreated on each connection)
 	engine *engine.Engine
+
+	// AI traffic fleet — tracks pending and active AI aircraft.
+	// Reset on each reconnect (ObjectIDs are invalidated across disconnects).
+	fleet *traffic.Fleet
 }
 
 // Handler function types that are part of the public Manager API

--- a/pkg/manager/lifecycle.go
+++ b/pkg/manager/lifecycle.go
@@ -74,11 +74,13 @@ func (m *Instance) runConnection() error {
 		m.mu.Lock()
 		m.engine = nil
 		m.mu.Unlock()
+		m.fleet.SetClient(nil)
 		return err
 	}
 
 	m.setState(StateConnected)
 	m.logger.Debug("[manager] Connected to simulator")
+	m.fleet.SetClient(m.engine)
 
 	// Process messages until disconnection or cancellation
 	stream := m.engine.Stream()
@@ -98,6 +100,7 @@ func (m *Instance) runConnection() error {
 				m.mu.Lock()
 				m.engine = nil
 				m.mu.Unlock()
+				m.fleet.SetClient(nil)
 				return nil // Return nil to allow reconnection
 			}
 

--- a/pkg/manager/main.go
+++ b/pkg/manager/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/mrlm-net/simconnect/pkg/manager/internal/instance"
+	"github.com/mrlm-net/simconnect/pkg/traffic"
 )
 
 // defaultSimState returns a new SimState with all fields initialized to their default/uninitialized values.
@@ -146,6 +147,7 @@ func New(name string, opts ...Option) Manager {
 		simRunningHandlers:     []instance.SimRunningHandlerEntry{},
 		customSystemEvents:     make(map[string]*instance.CustomSystemEvent),
 		customEventIDAlloc:     CustomEventIDMin,
-		requestRegistry:              NewRequestRegistry(),
+		requestRegistry:        NewRequestRegistry(),
+		fleet:                  traffic.NewFleet(nil),
 	}
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mrlm-net/simconnect/pkg/datasets"
 	"github.com/mrlm-net/simconnect/pkg/engine"
+	"github.com/mrlm-net/simconnect/pkg/traffic"
 	"github.com/mrlm-net/simconnect/pkg/types"
 )
 
@@ -436,6 +437,46 @@ type Manager interface {
 	// AICreateParkedATCAircraftEX1 creates a parked ATC aircraft with livery selection.
 	// Returns ErrNotConnected if not connected to the simulator.
 	AICreateParkedATCAircraftEX1(szContainerTitle string, szLivery string, szTailNumber string, szAirportID string, RequestID uint32) error
+
+	// Traffic Package Methods
+	// High-level AI aircraft management via pkg/traffic.Fleet.
+	// These wrap the raw AI* methods above with fleet tracking and typed options.
+
+	// Fleet returns the manager's internal aircraft fleet.
+	// Valid for the lifetime of the manager; reset (cleared) on each reconnect.
+	// Call Fleet().Acknowledge(reqID, objectID) from your ASSIGNED_OBJECT_ID handler.
+	Fleet() *traffic.Fleet
+
+	// TrafficParked queues a parked ATC aircraft creation at an airport gate.
+	// Returns ErrNotConnected if not connected to the simulator.
+	TrafficParked(opts traffic.ParkedOpts, reqID uint32) error
+
+	// TrafficEnroute queues an enroute ATC aircraft creation along a flight plan.
+	// Returns ErrNotConnected if not connected to the simulator.
+	TrafficEnroute(opts traffic.EnrouteOpts, reqID uint32) error
+
+	// TrafficNonATC queues a non-ATC aircraft creation at an explicit position.
+	// Returns ErrNotConnected if not connected to the simulator.
+	TrafficNonATC(opts traffic.NonATCOpts, reqID uint32) error
+
+	// TrafficRemove removes an AI aircraft from the simulation and from the fleet.
+	// Returns ErrNotConnected if not connected to the simulator.
+	TrafficRemove(objectID uint32, reqID uint32) error
+
+	// TrafficReleaseControl releases simulator control over a NonATC aircraft.
+	// Must be called before TrafficSetWaypoints.
+	// Returns ErrNotConnected if not connected to the simulator.
+	TrafficReleaseControl(objectID uint32, reqID uint32) error
+
+	// TrafficSetWaypoints assigns a waypoint chain to a non-ATC aircraft.
+	// Build wps with traffic.PushbackWaypoint, TaxiWaypoint, LineupWaypoint,
+	// ClimbWaypoint, and TakeoffClimb helpers.
+	// Returns ErrNotConnected if not connected to the simulator.
+	TrafficSetWaypoints(objectID uint32, defID uint32, wps []types.SIMCONNECT_DATA_WAYPOINT) error
+
+	// TrafficSetFlightPlan assigns a flight plan to an ATC aircraft.
+	// Returns ErrNotConnected if not connected to the simulator.
+	TrafficSetFlightPlan(objectID uint32, planPath string, reqID uint32) error
 
 	// Configuration getters
 

--- a/pkg/manager/traffic.go
+++ b/pkg/manager/traffic.go
@@ -1,0 +1,114 @@
+//go:build windows
+// +build windows
+
+package manager
+
+import (
+	"github.com/mrlm-net/simconnect/pkg/traffic"
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+// Fleet returns the manager's internal aircraft fleet.
+//
+// The fleet is valid for the lifetime of the manager but is reset (cleared) on
+// each reconnect — ObjectIDs are invalidated when the simulator disconnects.
+//
+// Usage pattern:
+//
+//	mgr.TrafficNonATC(opts, reqID)
+//	// ... receive SIMCONNECT_RECV_ID_ASSIGNED_OBJECT_ID ...
+//	aircraft, ok := mgr.Fleet().Acknowledge(reqID, objectID)
+//	mgr.Fleet().ReleaseControl(aircraft.ObjectID, releaseReqID)
+//	mgr.Fleet().SetWaypoints(aircraft.ObjectID, defID, wps)
+func (m *Instance) Fleet() *traffic.Fleet {
+	return m.fleet
+}
+
+// TrafficParked queues a parked ATC aircraft creation at an airport gate.
+// Returns ErrNotConnected if not connected to the simulator.
+//
+// An SIMCONNECT_RECV_ID_ASSIGNED_OBJECT_ID message will arrive shortly after;
+// call m.Fleet().Acknowledge(reqID, objectID) from your message handler to
+// register the aircraft in the fleet.
+func (m *Instance) TrafficParked(opts traffic.ParkedOpts, reqID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.fleet.RequestParked(opts, reqID)
+}
+
+// TrafficEnroute queues an enroute ATC aircraft creation along a flight plan.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) TrafficEnroute(opts traffic.EnrouteOpts, reqID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.fleet.RequestEnroute(opts, reqID)
+}
+
+// TrafficNonATC queues a non-ATC aircraft creation at an explicit position.
+// Returns ErrNotConnected if not connected to the simulator.
+//
+// After acknowledging the ObjectID, call TrafficReleaseControl followed by
+// TrafficSetWaypoints to begin waypoint-guided movement (pushback, taxi, takeoff).
+func (m *Instance) TrafficNonATC(opts traffic.NonATCOpts, reqID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.fleet.RequestNonATC(opts, reqID)
+}
+
+// TrafficRemove removes an AI aircraft from the simulation and from the fleet.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) TrafficRemove(objectID uint32, reqID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.fleet.Remove(objectID, reqID)
+}
+
+// TrafficReleaseControl releases simulator control over a NonATC aircraft.
+// Must be called before TrafficSetWaypoints — the simulator ignores waypoints
+// for aircraft it still holds under its own AI control.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) TrafficReleaseControl(objectID uint32, reqID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.fleet.ReleaseControl(objectID, reqID)
+}
+
+// TrafficSetWaypoints assigns a waypoint chain to a non-ATC aircraft.
+// defID must be a SimConnect data definition registered for "AI Waypoint List".
+// Build wps with traffic.PushbackWaypoint, traffic.TaxiWaypoint,
+// traffic.LineupWaypoint, traffic.ClimbWaypoint, and traffic.TakeoffClimb.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) TrafficSetWaypoints(objectID uint32, defID uint32, wps []types.SIMCONNECT_DATA_WAYPOINT) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.fleet.SetWaypoints(objectID, defID, wps)
+}
+
+// TrafficSetFlightPlan assigns a flight plan to an ATC aircraft.
+// Returns ErrNotConnected if not connected to the simulator.
+func (m *Instance) TrafficSetFlightPlan(objectID uint32, planPath string, reqID uint32) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.engine == nil {
+		return ErrNotConnected
+	}
+	return m.fleet.SetFlightPlan(objectID, planPath, reqID)
+}

--- a/pkg/traffic/aircraft.go
+++ b/pkg/traffic/aircraft.go
@@ -1,0 +1,20 @@
+//go:build windows
+// +build windows
+
+package traffic
+
+// Aircraft is a handle for a spawned AI aircraft whose ObjectID has been
+// confirmed by SimConnect. Handles are created by Fleet.Acknowledge and stored
+// inside the Fleet. All aircraft operations are performed through the Fleet.
+type Aircraft struct {
+	// ObjectID is the SimConnect object identifier assigned by the simulator.
+	ObjectID uint32
+	// Kind indicates how the aircraft was created (parked / enroute / non-ATC).
+	Kind AircraftKind
+	// Model is the container title string used during creation.
+	Model string
+	// Livery is the livery folder name used during creation ("" = default).
+	Livery string
+	// Tail is the tail number or identifier string used during creation.
+	Tail string
+}

--- a/pkg/traffic/errors.go
+++ b/pkg/traffic/errors.go
@@ -1,0 +1,22 @@
+//go:build windows
+// +build windows
+
+package traffic
+
+import "errors"
+
+var (
+	// ErrNotConnected is returned when the fleet's engine client is nil.
+	ErrNotConnected = errors.New("traffic: not connected to simulator")
+
+	// ErrObjectNotFound is returned when an operation targets an ObjectID that
+	// is not tracked in the fleet.
+	ErrObjectNotFound = errors.New("traffic: object ID not found in fleet")
+
+	// ErrCreationFailed is returned when an aircraft creation call fails.
+	ErrCreationFailed = errors.New("traffic: aircraft creation failed")
+
+	// ErrEmptyWaypoints is returned when SetWaypoints is called with a nil or
+	// zero-length waypoint slice.
+	ErrEmptyWaypoints = errors.New("traffic: waypoints slice must not be empty")
+)

--- a/pkg/traffic/fleet.go
+++ b/pkg/traffic/fleet.go
@@ -1,0 +1,300 @@
+//go:build windows
+// +build windows
+
+package traffic
+
+import (
+	"sync"
+	"unsafe"
+
+	"github.com/mrlm-net/simconnect/pkg/engine"
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+// Fleet manages a thread-safe collection of AI aircraft bound to a single
+// engine client. It tracks both pending creations (awaiting ObjectID assignment
+// from SIMCONNECT_RECV_ID_ASSIGNED_OBJECT_ID) and active aircraft.
+//
+// Lifecycle:
+//
+//   - Create with NewFleet (typically inside a Manager or your own controller).
+//   - Call Request* to spawn aircraft — each issues the SimConnect creation call
+//     and records a Pending entry keyed by reqID.
+//   - On receiving SIMCONNECT_RECV_ID_ASSIGNED_OBJECT_ID, call Acknowledge to
+//     promote the Pending entry to a full Aircraft tracked by ObjectID.
+//   - On disconnect / reconnect, call SetClient(newClient) which also clears all
+//     stale pending and member state (ObjectIDs are invalid after a disconnect).
+type Fleet struct {
+	mu      sync.RWMutex
+	pending map[uint32]*Pending  // reqID → pending creation
+	members map[uint32]*Aircraft // objectID → active aircraft
+	client  engine.Client
+}
+
+// NewFleet constructs a Fleet bound to the given engine client.
+// Pass nil to create an unconnected fleet and call SetClient later.
+func NewFleet(client engine.Client) *Fleet {
+	return &Fleet{
+		pending: make(map[uint32]*Pending),
+		members: make(map[uint32]*Aircraft),
+		client:  client,
+	}
+}
+
+// SetClient updates the engine client reference and clears all pending and
+// member state. Call this on connect (passing the new client) and on disconnect
+// (passing nil). ObjectIDs are invalidated across reconnects so the fleet must
+// be reset each time.
+func (f *Fleet) SetClient(client engine.Client) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.client = client
+	f.pending = make(map[uint32]*Pending)
+	f.members = make(map[uint32]*Aircraft)
+}
+
+// ── Creation requests (async) ─────────────────────────────────────────────
+
+// RequestParked queues a parked ATC aircraft creation.
+// The ObjectID is assigned asynchronously; call Acknowledge from your
+// SIMCONNECT_RECV_ID_ASSIGNED_OBJECT_ID handler to complete the handle.
+// Returns ErrNotConnected if the fleet has no active client.
+func (f *Fleet) RequestParked(opts ParkedOpts, reqID uint32) error {
+	f.mu.RLock()
+	c := f.client
+	f.mu.RUnlock()
+	if c == nil {
+		return ErrNotConnected
+	}
+	var err error
+	if opts.Livery != "" {
+		err = c.AICreateParkedATCAircraftEX1(opts.Model, opts.Livery, opts.Tail, opts.Airport, reqID)
+	} else {
+		err = c.AICreateParkedATCAircraft(opts.Model, opts.Tail, opts.Airport, reqID)
+	}
+	if err != nil {
+		return err
+	}
+	f.mu.Lock()
+	f.pending[reqID] = &Pending{ReqID: reqID, Kind: KindParked, Model: opts.Model, Livery: opts.Livery, Tail: opts.Tail}
+	f.mu.Unlock()
+	return nil
+}
+
+// RequestEnroute queues an enroute ATC aircraft creation along a flight plan.
+// Returns ErrNotConnected if the fleet has no active client.
+func (f *Fleet) RequestEnroute(opts EnrouteOpts, reqID uint32) error {
+	f.mu.RLock()
+	c := f.client
+	f.mu.RUnlock()
+	if c == nil {
+		return ErrNotConnected
+	}
+	var err error
+	if opts.Livery != "" {
+		err = c.AICreateEnrouteATCAircraftEX1(opts.Model, opts.Livery, opts.Tail, opts.FlightNumber, opts.FlightPlan, opts.Phase, opts.TouchAndGo, reqID)
+	} else {
+		err = c.AICreateEnrouteATCAircraft(opts.Model, opts.Tail, opts.FlightNumber, opts.FlightPlan, opts.Phase, opts.TouchAndGo, reqID)
+	}
+	if err != nil {
+		return err
+	}
+	f.mu.Lock()
+	f.pending[reqID] = &Pending{ReqID: reqID, Kind: KindEnroute, Model: opts.Model, Livery: opts.Livery, Tail: opts.Tail}
+	f.mu.Unlock()
+	return nil
+}
+
+// RequestNonATC queues a non-ATC aircraft creation at an explicit position.
+// These aircraft follow a waypoint chain rather than ATC instructions.
+// After Acknowledge, call ReleaseControl then SetWaypoints to begin movement.
+// Returns ErrNotConnected if the fleet has no active client.
+func (f *Fleet) RequestNonATC(opts NonATCOpts, reqID uint32) error {
+	f.mu.RLock()
+	c := f.client
+	f.mu.RUnlock()
+	if c == nil {
+		return ErrNotConnected
+	}
+	var err error
+	if opts.Livery != "" {
+		err = c.AICreateNonATCAircraftEX1(opts.Model, opts.Livery, opts.Tail, opts.Position, reqID)
+	} else {
+		err = c.AICreateNonATCAircraft(opts.Model, opts.Tail, opts.Position, reqID)
+	}
+	if err != nil {
+		return err
+	}
+	f.mu.Lock()
+	f.pending[reqID] = &Pending{ReqID: reqID, Kind: KindNonATC, Model: opts.Model, Livery: opts.Livery, Tail: opts.Tail}
+	f.mu.Unlock()
+	return nil
+}
+
+// ── Acknowledge ────────────────────────────────────────────────────────────
+
+// Acknowledge resolves a pending creation with the ObjectID returned by SimConnect.
+// Call this from your SIMCONNECT_RECV_ID_ASSIGNED_OBJECT_ID handler.
+//
+// Returns the created Aircraft and true if reqID was a known pending request.
+// Returns nil and false when the reqID is unrecognised (belongs to another subsystem).
+func (f *Fleet) Acknowledge(reqID uint32, objectID uint32) (*Aircraft, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	p, ok := f.pending[reqID]
+	if !ok {
+		return nil, false
+	}
+	delete(f.pending, reqID)
+	a := &Aircraft{
+		ObjectID: objectID,
+		Kind:     p.Kind,
+		Model:    p.Model,
+		Livery:   p.Livery,
+		Tail:     p.Tail,
+	}
+	f.members[objectID] = a
+	return a, true
+}
+
+// ── Aircraft operations ────────────────────────────────────────────────────
+
+// Remove removes an AI aircraft from the simulation and from the fleet.
+// Returns ErrNotConnected if the fleet has no active client.
+func (f *Fleet) Remove(objectID uint32, reqID uint32) error {
+	f.mu.RLock()
+	c := f.client
+	f.mu.RUnlock()
+	if c == nil {
+		return ErrNotConnected
+	}
+	if err := c.AIRemoveObject(objectID, reqID); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	delete(f.members, objectID)
+	f.mu.Unlock()
+	return nil
+}
+
+// ReleaseControl releases SimConnect control over an aircraft, handing it back
+// to the simulator's AI system. This must be called before sending a waypoint
+// chain to a NonATC aircraft — the simulator will not honour waypoints for an
+// aircraft it still holds under its own control.
+// Returns ErrNotConnected if the fleet has no active client.
+func (f *Fleet) ReleaseControl(objectID uint32, reqID uint32) error {
+	f.mu.RLock()
+	c := f.client
+	f.mu.RUnlock()
+	if c == nil {
+		return ErrNotConnected
+	}
+	return c.AIReleaseControl(objectID, reqID)
+}
+
+// SetWaypoints assigns a waypoint chain to a non-ATC aircraft.
+// defID must be a SimConnect data definition registered for "AI Waypoint List"
+// (type SIMCONNECT_DATATYPE_WAYPOINT). Build the waypoint slice using the helpers
+// in this package: PushbackWaypoint, TaxiWaypoint, LineupWaypoint, ClimbWaypoint,
+// and TakeoffClimb.
+//
+// Call ReleaseControl before SetWaypoints — the simulator will otherwise ignore
+// the waypoints.
+// Returns ErrNotConnected if the fleet has no active client.
+// Returns ErrEmptyWaypoints if wps is nil or empty.
+func (f *Fleet) SetWaypoints(objectID uint32, defID uint32, wps []types.SIMCONNECT_DATA_WAYPOINT) error {
+	if len(wps) == 0 {
+		return ErrEmptyWaypoints
+	}
+	f.mu.RLock()
+	c := f.client
+	f.mu.RUnlock()
+	if c == nil {
+		return ErrNotConnected
+	}
+	packed := engine.PackWaypoints(wps)
+	return c.SetDataOnSimObject(
+		defID,
+		objectID,
+		types.SIMCONNECT_DATA_SET_FLAG_DEFAULT,
+		uint32(len(wps)),
+		engine.WaypointWireSize,
+		unsafe.Pointer(&packed[0]),
+	)
+}
+
+// SetFlightPlan assigns a flight plan to an ATC aircraft (parked or enroute).
+// Returns ErrNotConnected if the fleet has no active client.
+func (f *Fleet) SetFlightPlan(objectID uint32, planPath string, reqID uint32) error {
+	f.mu.RLock()
+	c := f.client
+	f.mu.RUnlock()
+	if c == nil {
+		return ErrNotConnected
+	}
+	return c.AISetAircraftFlightPlan(objectID, planPath, reqID)
+}
+
+// ── Collection ─────────────────────────────────────────────────────────────
+
+// Get returns the Aircraft for the given ObjectID.
+// Returns (nil, false) if the ObjectID is not tracked in the fleet.
+func (f *Fleet) Get(objectID uint32) (*Aircraft, bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	a, ok := f.members[objectID]
+	return a, ok
+}
+
+// List returns a snapshot of all currently tracked Aircraft.
+func (f *Fleet) List() []*Aircraft {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	result := make([]*Aircraft, 0, len(f.members))
+	for _, a := range f.members {
+		result = append(result, a)
+	}
+	return result
+}
+
+// Len returns the number of active (acknowledged) aircraft in the fleet.
+func (f *Fleet) Len() int {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return len(f.members)
+}
+
+// RemoveAll removes all tracked aircraft from the simulation.
+// reqIDBase is used as the base request ID; each aircraft is assigned
+// reqIDBase + i for i in [0, len). Returns the last non-nil error encountered.
+func (f *Fleet) RemoveAll(reqIDBase uint32) error {
+	f.mu.RLock()
+	c := f.client
+	ids := make([]uint32, 0, len(f.members))
+	for id := range f.members {
+		ids = append(ids, id)
+	}
+	f.mu.RUnlock()
+	if c == nil {
+		return ErrNotConnected
+	}
+	var last error
+	for i, id := range ids {
+		if err := c.AIRemoveObject(id, reqIDBase+uint32(i)); err != nil {
+			last = err
+		}
+	}
+	f.mu.Lock()
+	f.members = make(map[uint32]*Aircraft)
+	f.mu.Unlock()
+	return last
+}
+
+// Clear resets the fleet without issuing removal requests to the simulator.
+// Use this after a disconnect when all ObjectIDs are already stale.
+func (f *Fleet) Clear() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pending = make(map[uint32]*Pending)
+	f.members = make(map[uint32]*Aircraft)
+}

--- a/pkg/traffic/types.go
+++ b/pkg/traffic/types.go
@@ -1,0 +1,59 @@
+//go:build windows
+// +build windows
+
+package traffic
+
+import "github.com/mrlm-net/simconnect/pkg/types"
+
+// AircraftKind identifies how an AI aircraft was created.
+type AircraftKind uint8
+
+const (
+	// KindParked — created via AICreateParkedATCAircraft / EX1.
+	KindParked AircraftKind = iota
+	// KindEnroute — created via AICreateEnrouteATCAircraft / EX1 with a flight plan.
+	KindEnroute
+	// KindNonATC — created via AICreateNonATCAircraftEX1 at an explicit position.
+	// These aircraft follow a waypoint chain rather than ATC instructions.
+	KindNonATC
+)
+
+// ParkedOpts configures a parked ATC aircraft at an airport gate.
+type ParkedOpts struct {
+	Model   string // container title (e.g. "FSLTL A320 Air France SL")
+	Livery  string // livery folder name; "" selects the default livery
+	Tail    string // ATC tail number (e.g. "AFR123")
+	Airport string // ICAO airport code (e.g. "LKPR")
+}
+
+// EnrouteOpts configures an enroute ATC aircraft along a flight plan.
+type EnrouteOpts struct {
+	Model        string  // container title
+	Livery       string  // livery folder name; "" selects the default livery
+	Tail         string  // ATC tail number
+	FlightNumber uint32  // ATC flight number used for ATC comms
+	FlightPlan   string  // path to a .PLN or MSFS flight plan file
+	Phase        float64 // plan start offset — 0.0 = beginning, 1.0 = end
+	TouchAndGo   bool    // enable touch-and-go mode on arrival
+}
+
+// NonATCOpts configures a non-ATC aircraft placed at an explicit initial position.
+// Use this for aircraft that will follow a hand-built waypoint chain (e.g.
+// pushback → taxi → takeoff) rather than ATC routing.
+type NonATCOpts struct {
+	Model    string                             // container title
+	Livery   string                             // livery folder name; "" selects the default livery
+	Tail     string                             // identifier visible in telemetry
+	Position types.SIMCONNECT_DATA_INITPOSITION // initial position on spawn
+}
+
+// Pending records the metadata for an aircraft creation request that is still
+// awaiting an ObjectID from the simulator. Created internally by Fleet.Request*
+// and resolved to an Aircraft by Fleet.Acknowledge.
+type Pending struct {
+	ReqID  uint32
+	Kind   AircraftKind
+	Model  string
+	Livery string
+	Tail   string
+}

--- a/pkg/traffic/waypoints.go
+++ b/pkg/traffic/waypoints.go
@@ -1,0 +1,118 @@
+//go:build windows
+// +build windows
+
+package traffic
+
+import (
+	"math"
+
+	"github.com/mrlm-net/simconnect/pkg/convert"
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+// PushbackWaypoint creates a waypoint for a reverse pushback manoeuvre.
+//
+// Flags: ON_GROUND | REVERSE | SPEED_REQUESTED.
+//
+// Set lat/lon to the taxiway centreline node where the pushback ends — typically
+// one or two hops from the gate spur entry node toward the main taxiway.
+// A speed of 2–4 kts matches a realistic pushback truck pace.
+func PushbackWaypoint(lat, lon, altFt, ktsSpeed float64) types.SIMCONNECT_DATA_WAYPOINT {
+	return types.SIMCONNECT_DATA_WAYPOINT{
+		Latitude:  lat,
+		Longitude: lon,
+		Altitude:  altFt,
+		Flags: uint32(types.SIMCONNECT_WAYPOINT_ON_GROUND |
+			types.SIMCONNECT_WAYPOINT_REVERSE |
+			types.SIMCONNECT_WAYPOINT_SPEED_REQUESTED),
+		KtsSpeed: ktsSpeed,
+	}
+}
+
+// TaxiWaypoint creates a ground taxi waypoint.
+//
+// Flags: ON_GROUND | SPEED_REQUESTED.
+//
+// Typical taxi speed is 12–18 kts. Use this for each node along the taxi route
+// from the taxiway centreline to the runway threshold.
+func TaxiWaypoint(lat, lon, altFt, ktsSpeed float64) types.SIMCONNECT_DATA_WAYPOINT {
+	return types.SIMCONNECT_DATA_WAYPOINT{
+		Latitude:  lat,
+		Longitude: lon,
+		Altitude:  altFt,
+		Flags: uint32(types.SIMCONNECT_WAYPOINT_ON_GROUND |
+			types.SIMCONNECT_WAYPOINT_SPEED_REQUESTED),
+		KtsSpeed: ktsSpeed,
+	}
+}
+
+// LineupWaypoint creates the final ground waypoint at the runway threshold.
+//
+// Flags: ON_GROUND | SPEED_REQUESTED at 5 kts for precise lineup.
+//
+// Placing this as the last ON_GROUND waypoint immediately before a ClimbWaypoint
+// sequence triggers the simulator's takeoff roll when the AI transitions to the
+// first airborne waypoint.
+func LineupWaypoint(lat, lon, altFt float64) types.SIMCONNECT_DATA_WAYPOINT {
+	return TaxiWaypoint(lat, lon, altFt, 5)
+}
+
+// ClimbWaypoint creates an airborne climb waypoint.
+//
+// Flags: SPEED_REQUESTED | THROTTLE_REQUESTED | COMPUTE_VERTICAL_SPEED | ALTITUDE_IS_AGL.
+//
+// altAGL is height above ground level in feet. throttlePct is 0–100.
+// COMPUTE_VERTICAL_SPEED lets the simulator derive the required vertical speed
+// to reach each altitude at the waypoint. ALTITUDE_IS_AGL makes altitudes
+// terrain-relative rather than MSL.
+//
+// The transition from the last ON_GROUND waypoint to the first ClimbWaypoint
+// triggers the takeoff roll and rotation sequence.
+func ClimbWaypoint(lat, lon, altAGL, ktsSpeed, throttlePct float64) types.SIMCONNECT_DATA_WAYPOINT {
+	return types.SIMCONNECT_DATA_WAYPOINT{
+		Latitude:  lat,
+		Longitude: lon,
+		Altitude:  altAGL,
+		Flags: uint32(
+			types.SIMCONNECT_WAYPOINT_SPEED_REQUESTED |
+				types.SIMCONNECT_WAYPOINT_THROTTLE_REQUESTED |
+				types.SIMCONNECT_WAYPOINT_COMPUTE_VERTICAL_SPEED |
+				types.SIMCONNECT_WAYPOINT_ALTITUDE_IS_AGL,
+		),
+		KtsSpeed:        ktsSpeed,
+		PercentThrottle: throttlePct,
+	}
+}
+
+// TakeoffClimb builds the standard 3-waypoint climb chain from a runway threshold.
+//
+// rwyLat/rwyLon is the primary runway threshold. hdgDeg is the primary runway
+// heading (the direction the aircraft will climb toward).
+//
+// Returns 3 ClimbWaypoints:
+//   - 1.5 nm out / 1 500 ft AGL / 200 kts / 100 % throttle
+//   - 5.0 nm out / 4 000 ft AGL / 240 kts /  90 % throttle
+//   - 12  nm out / 9 000 ft AGL / 280 kts /  85 % throttle
+//
+// Append these directly after a LineupWaypoint to complete a full departure
+// sequence: [PushbackWaypoint] [TaxiWaypoint...] [LineupWaypoint] [TakeoffClimb...]
+func TakeoffClimb(rwyLat, rwyLon, hdgDeg float64) []types.SIMCONNECT_DATA_WAYPOINT {
+	c1Lat, c1Lon := ahead(rwyLat, rwyLon, hdgDeg, 2778)  // 1.5 nm
+	c2Lat, c2Lon := ahead(rwyLat, rwyLon, hdgDeg, 9260)  // 5 nm
+	c3Lat, c3Lon := ahead(rwyLat, rwyLon, hdgDeg, 22224) // 12 nm
+	return []types.SIMCONNECT_DATA_WAYPOINT{
+		ClimbWaypoint(c1Lat, c1Lon, 1500, 200, 100),
+		ClimbWaypoint(c2Lat, c2Lon, 4000, 240, 90),
+		ClimbWaypoint(c3Lat, c3Lon, 9000, 280, 85),
+	}
+}
+
+// ahead returns the lat/lon displaced from (lat, lon) by the given distance in
+// meters along heading hdgDeg. Uses convert.OffsetToLatLon under the hood.
+func ahead(lat, lon, hdgDeg, meters float64) (float64, float64) {
+	rad := hdgDeg * math.Pi / 180
+	return convert.OffsetToLatLon(lat, lon,
+		meters*math.Sin(rad), // east component (X)
+		meters*math.Cos(rad), // north component (Z)
+	)
+}


### PR DESCRIPTION
## Summary

Introduces `pkg/traffic` — a typed abstraction layer over the raw SimConnect AI object API. This is a *sketch* implementation that encodes everything proven by the `manage-traffic` and `ai-traffic` examples, while explicitly deferring taxiway routing and ground navigation controllers to a later milestone once we have a complete understanding of sim data.

### What's in

- **`pkg/traffic/types.go`** — `AircraftKind`, `ParkedOpts`, `EnrouteOpts`, `NonATCOpts`, `Pending`
- **`pkg/traffic/aircraft.go`** — `Aircraft` data handle (ObjectID, Kind, Model, Livery, Tail)
- **`pkg/traffic/errors.go`** — Sentinel errors: `ErrNotConnected`, `ErrObjectNotFound`, `ErrCreationFailed`, `ErrEmptyWaypoints`
- **`pkg/traffic/fleet.go`** — `Fleet` with thread-safe `Request*`/`Acknowledge`/`Remove`/`ReleaseControl`/`SetWaypoints`/`SetFlightPlan`
- **`pkg/traffic/waypoints.go`** — Waypoint constructors with correct flag combinations (`PushbackWaypoint`, `TaxiWaypoint`, `LineupWaypoint`, `ClimbWaypoint`, `TakeoffClimb`) — lessons from manage-traffic baked in
- **`pkg/manager/traffic.go`** — `Traffic*` delegation methods and `Fleet()` accessor on the Manager
- Manager `instance.go`, `main.go`, `lifecycle.go`, `manager.go` updated to wire fleet lifecycle (SetClient on connect/disconnect)

### What's NOT in (deferred)

- Taxiway graph routing (BFS, Dijkstra) — stays in manage-traffic example until we understand ground navigation fully
- Facility data querying — stays in engine / facility layer
- Any "controller" abstractions (takeoff controller, ground controller) — future milestone

### Async creation pattern

SimConnect aircraft creation is inherently async. The `Fleet` tracks pending creations by `reqID` and promotes them to `Aircraft` handles when the caller calls `Fleet().Acknowledge(reqID, objectID)` from their `SIMCONNECT_RECV_ID_ASSIGNED_OBJECT_ID` handler.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet -unsafeptr=false ./...` passes
- [ ] Verify `manage-traffic` example still compiles unmodified (no breaking changes to engine/types)
- [ ] Manual smoke test: spawn a NonATC aircraft via `mgr.TrafficNonATC(...)`, acknowledge ObjectID, call `TrafficReleaseControl` + `TrafficSetWaypoints` with `TakeoffClimb`

Closes #36
Closes #37
Part of #27