### PR TITLE
feat(convert): add LatLonToOffset as exported inverse of OffsetToLatLon

### DIFF
--- a/pkg/convert/position.go
+++ b/pkg/convert/position.go
@@ -32,3 +32,37 @@ func OffsetToLatLon(latRef, lonRef, xEast, zNorth float64) (lat, lon float64) {
 	lon = lonRef + deltaLon
 	return
 }
+
+// LatLonToOffset is the inverse of OffsetToLatLon. Given a reference point
+// (latRef, lonRef in decimal degrees) and a target point (lat, lon in decimal
+// degrees), it returns the east (xEast) and north (zNorth) meter offsets of
+// the target from the reference point using the WGS84 ellipsoid.
+//
+// Parameter order matches OffsetToLatLon for symmetry:
+//
+//	xEast, zNorth := LatLonToOffset(latRef, lonRef, lat, lon)
+//	lat2, lon2    := OffsetToLatLon(latRef, lonRef, xEast, zNorth)
+//	// lat2 ≈ lat, lon2 ≈ lon (within floating-point precision)
+//
+// Pole guard: when math.Abs(latRef) >= 90, the eastward direction is
+// undefined; xEast is returned as 0 to avoid a division-by-zero singularity.
+func LatLonToOffset(latRef, lonRef, lat, lon float64) (xEast, zNorth float64) {
+	// WGS84 ellipsoid
+	const a = 6378137.0
+	const b = 6356752.314245
+	e2 := (a*a - b*b) / (a * a)
+
+	latRefRad := latRef * math.Pi / 180.0
+	sinLat := math.Sin(latRefRad)
+	w := math.Sqrt(1 - e2*sinLat*sinLat)
+
+	// Meridian radius of curvature (M) and prime vertical radius (N)
+	M := a * (1 - e2) / (w * w * w)
+	N := a / w
+
+	zNorth = (lat - latRef) * (math.Pi / 180.0) * M
+	if math.Abs(latRef) < 90.0 {
+		xEast = (lon - lonRef) * (math.Pi / 180.0) * N * math.Cos(latRefRad)
+	}
+	return
+}

--- a/pkg/convert/position_test.go
+++ b/pkg/convert/position_test.go
@@ -98,3 +98,123 @@ func TestOffsetToLatLon(t *testing.T) {
 		})
 	}
 }
+
+func TestLatLonToOffset(t *testing.T) {
+	// epsilonM is 0.01m tolerance for meter offset comparisons.
+	const epsilonM = 0.01
+
+	tests := []struct {
+		name       string
+		latRef     float64
+		lonRef     float64
+		lat        float64
+		lon        float64
+		wantXEast  float64
+		wantZNorth float64
+		tolerance  float64
+	}{
+		{
+			name:       "zero delta — same point",
+			latRef:     0, lonRef: 0,
+			lat:        0, lon: 0,
+			wantXEast:  0, wantZNorth: 0,
+			tolerance: epsilon,
+		},
+		{
+			// Exact lat computed from OffsetToLatLon(0,0,0,1000): 0.009043694770504°
+			name:       "1000m north at equator",
+			latRef:     0, lonRef: 0,
+			lat:        0.009043694770504, lon: 0,
+			wantXEast:  0, wantZNorth: 1000,
+			tolerance: epsilonM,
+		},
+		{
+			// Exact lon computed from OffsetToLatLon(0,0,1000,0): 0.008983152841195°
+			name:       "1000m east at equator",
+			latRef:     0, lonRef: 0,
+			lat:        0, lon: 0.008983152841195,
+			wantXEast:  1000, wantZNorth: 0,
+			tolerance: epsilonM,
+		},
+		{
+			// Exact lat computed from OffsetToLatLon(60,10,0,1000): 60.008975670662707°
+			name:       "1000m north at 60N",
+			latRef:     60, lonRef: 10,
+			lat:        60.008975670662707, lon: 10,
+			wantXEast:  0, wantZNorth: 1000,
+			tolerance: epsilonM,
+		},
+		{
+			// Exact lon computed from OffsetToLatLon(60,10,1000,0): 10.017921146448389°
+			name:       "1000m east at 60N",
+			latRef:     60, lonRef: 10,
+			lat:        60, lon: 10.017921146448389,
+			wantXEast:  1000, wantZNorth: 0,
+			tolerance: epsilonM,
+		},
+		{
+			// Exact values from OffsetToLatLon(0,0,-1000,-1000)
+			name:       "negative offsets — south and west",
+			latRef:     0, lonRef: 0,
+			lat:        -0.009043694770504, lon: -0.008983152841195,
+			wantXEast:  -1000, wantZNorth: -1000,
+			tolerance: epsilonM,
+		},
+		{
+			name:       "pole guard — xEast must be zero at north pole",
+			latRef:     90, lonRef: 0,
+			lat:        90, lon: 1,
+			wantXEast:  0, wantZNorth: 0,
+			tolerance: epsilon,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotXEast, gotZNorth := LatLonToOffset(tt.latRef, tt.lonRef, tt.lat, tt.lon)
+			if math.Abs(gotXEast-tt.wantXEast) > tt.tolerance {
+				t.Errorf("xEast: got %v, want %v (diff %v)", gotXEast, tt.wantXEast, math.Abs(gotXEast-tt.wantXEast))
+			}
+			if math.Abs(gotZNorth-tt.wantZNorth) > tt.tolerance {
+				t.Errorf("zNorth: got %v, want %v (diff %v)", gotZNorth, tt.wantZNorth, math.Abs(gotZNorth-tt.wantZNorth))
+			}
+		})
+	}
+}
+
+func TestLatLonToOffset_RoundTrip(t *testing.T) {
+	// Round-trip: OffsetToLatLon → LatLonToOffset must recover the original
+	// offsets within 0.01m.
+	const roundTripTolerance = 0.01
+
+	cases := []struct {
+		name   string
+		latRef float64
+		lonRef float64
+		xEast  float64
+		zNorth float64
+	}{
+		{"equator zero offsets", 0, 0, 0, 0},
+		{"equator north", 0, 0, 0, 1000},
+		{"equator east", 0, 0, 1000, 0},
+		{"equator combined", 0, 0, 500, 800},
+		{"60N large north", 60, 10, 0, 5000},
+		{"60N large east", 60, 10, 5000, 0},
+		{"60N combined", 60, 10, 2000, 3000},
+		{"mid-lat negative", 45, -90, -1500, -2500},
+		{"southern hemisphere", -30, 20, 700, 1300},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lat, lon := OffsetToLatLon(tc.latRef, tc.lonRef, tc.xEast, tc.zNorth)
+			gotXEast, gotZNorth := LatLonToOffset(tc.latRef, tc.lonRef, lat, lon)
+			if math.Abs(gotXEast-tc.xEast) > roundTripTolerance {
+				t.Errorf("xEast round-trip: got %v, want %v (diff %v)", gotXEast, tc.xEast, math.Abs(gotXEast-tc.xEast))
+			}
+			if math.Abs(gotZNorth-tc.zNorth) > roundTripTolerance {
+				t.Errorf("zNorth round-trip: got %v, want %v (diff %v)", gotZNorth, tc.zNorth, math.Abs(gotZNorth-tc.zNorth))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Exports `LatLonToOffset(latRef, lonRef, lat, lon float64) (xEast, zNorth float64)` from `pkg/convert/position.go`
- Promotes the private `latLonToOffset` helper from `examples/manage-traffic/main.go` to a first-class public API
- Uses the same inline WGS84 constants (`const a = 6378137.0`, `const b = 6356752.314245`) and ellipsoid math as `OffsetToLatLon`, matching the existing style — no package-level constants introduced
- Pole guard: `math.Abs(latRef) >= 90.0` forces `xEast = 0`, symmetric with `OffsetToLatLon`

## Test plan

- [ ] `TestLatLonToOffset` — 6 direct cases: zero delta, 1000m north at equator, 1000m east at equator, 1000m north at 60N, 1000m east at 60N, negative offsets, pole guard at north pole
- [ ] `TestLatLonToOffset_RoundTrip` — 9 cases: `OffsetToLatLon` → `LatLonToOffset` recovers original offsets within 0.01m tolerance
- [ ] `go build ./pkg/convert/...` — passes
- [ ] `go test ./pkg/convert/...` — 25/25 PASS
- [ ] `go vet -unsafeptr=false ./pkg/convert/...` — clean

Closes #211