### PR TITLE
feat(calc): add BearingFromOffsets to pkg/calc/bearing.go

### DIFF
--- a/pkg/calc/bearing.go
+++ b/pkg/calc/bearing.go
@@ -14,3 +14,10 @@ func BearingDegrees(lat1, lon1, lat2, lon2 float64) float64 {
 	theta := math.Atan2(x, y) * 180.0 / math.Pi
 	return math.Mod(theta+360.0, 360.0)
 }
+
+// BearingFromOffsets returns the bearing in degrees [0, 360) from the local
+// coordinate origin toward (xEast, zNorth). Uses SimConnect convention: X=east,
+// Z=north. Returns 0 for the zero vector (both inputs are 0).
+func BearingFromOffsets(xEast, zNorth float64) float64 {
+	return math.Mod(math.Atan2(xEast, zNorth)*180.0/math.Pi+360.0, 360.0)
+}

--- a/pkg/calc/bearing.go
+++ b/pkg/calc/bearing.go
@@ -16,8 +16,14 @@ func BearingDegrees(lat1, lon1, lat2, lon2 float64) float64 {
 }
 
 // BearingFromOffsets returns the bearing in degrees [0, 360) from the local
-// coordinate origin toward (xEast, zNorth). Uses SimConnect convention: X=east,
-// Z=north. Returns 0 for the zero vector (both inputs are 0).
+// coordinate origin toward the point (xEast, zNorth), where xEast is the
+// eastward offset and zNorth is the northward offset, both in any consistent
+// linear unit (metres, feet, SimConnect BiasX/BiasZ units).
+//
+// The coordinate convention matches SimConnect's local airport frame:
+// X is east, Z is north.
+//
+// Returns 0 for the degenerate case where both offsets are zero.
 func BearingFromOffsets(xEast, zNorth float64) float64 {
 	return math.Mod(math.Atan2(xEast, zNorth)*180.0/math.Pi+360.0, 360.0)
 }

--- a/pkg/calc/bearing_test.go
+++ b/pkg/calc/bearing_test.go
@@ -64,3 +64,51 @@ func TestBearingDegreesRange(t *testing.T) {
 		}
 	}
 }
+
+func TestBearingFromOffsets(t *testing.T) {
+	const tol = 1e-9
+	tests := []struct {
+		name        string
+		xEast       float64
+		zNorth      float64
+		wantBearing float64
+		tolerance   float64
+	}{
+		{name: "pure north", xEast: 0, zNorth: 1, wantBearing: 0, tolerance: tol},
+		{name: "pure east", xEast: 1, zNorth: 0, wantBearing: 90, tolerance: tol},
+		{name: "pure south", xEast: 0, zNorth: -1, wantBearing: 180, tolerance: tol},
+		{name: "pure west", xEast: -1, zNorth: 0, wantBearing: 270, tolerance: tol},
+		{name: "NE diagonal", xEast: 1, zNorth: 1, wantBearing: 45, tolerance: tol},
+		{name: "SW diagonal", xEast: -1, zNorth: -1, wantBearing: 225, tolerance: tol},
+		{name: "zero vector", xEast: 0, zNorth: 0, wantBearing: 0, tolerance: tol},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BearingFromOffsets(tt.xEast, tt.zNorth)
+			if got < 0 || got >= 360 {
+				t.Errorf("BearingFromOffsets(%v, %v) = %v, not in [0,360)", tt.xEast, tt.zNorth, got)
+			}
+			if math.Abs(got-tt.wantBearing) > tt.tolerance {
+				t.Errorf("BearingFromOffsets(%v, %v) = %v, want %v", tt.xEast, tt.zNorth, got, tt.wantBearing)
+			}
+		})
+	}
+}
+
+func TestBearingFromOffsetsRange(t *testing.T) {
+	// Verify result is always in [0, 360) for a variety of non-trivial inputs.
+	inputs := [][2]float64{
+		{3, 4},
+		{-7, 2},
+		{5, -5},
+		{100, 1},
+		{-0.5, -0.5},
+		{1000, -1},
+	}
+	for _, p := range inputs {
+		got := BearingFromOffsets(p[0], p[1])
+		if got < 0 || got >= 360 {
+			t.Errorf("BearingFromOffsets(%v, %v) = %v, not in [0,360)", p[0], p[1], got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Appends `BearingFromOffsets(xEast, zNorth float64) float64` to `pkg/calc/bearing.go`
- Promotes the inline bearing calculation from `examples/manage-traffic/main.go` (`gateSpawnHeading`) to a first-class exported function
- Formula: `math.Mod(math.Atan2(xEast, zNorth)*180.0/math.Pi + 360.0, 360.0)` — uses SimConnect local airport frame (X=east, Z=north)
- Two new test functions appended to `pkg/calc/bearing_test.go`: `TestBearingFromOffsets` (7 cardinal/diagonal/zero cases, tolerance 1e-9) and `TestBearingFromOffsetsRange` (6 non-trivial inputs verifying [0,360) invariant)

## Test plan

- [x] `go build ./pkg/calc/...` passes
- [x] `go test ./pkg/calc/... -v` — all 9 new subtests pass (pure N/E/S/W, NE/SW diagonals, zero vector, range invariant)
- [x] No `//go:build` tag added
- [x] No external dependencies introduced

Closes #213