### PR TITLE
fix(calc): correct godoc placement in pkg/calc/haversine.go

### DIFF
--- a/pkg/calc/haversine.go
+++ b/pkg/calc/haversine.go
@@ -2,12 +2,12 @@ package calc
 
 import "math"
 
-// HaversineMeters calculates the great-circle distance in meters between two
-// geographic coordinates using the haversine formula. Input coordinates are in
-// decimal degrees. Uses Earth mean radius of 6,371,000 meters.
 // earthRadiusM is the mean Earth radius in metres used across all great-circle calculations.
 const earthRadiusM = 6371000.0
 
+// HaversineMeters calculates the great-circle distance in meters between two
+// geographic coordinates using the haversine formula. Input coordinates are in
+// decimal degrees. Uses Earth mean radius of 6,371,000 meters.
 func HaversineMeters(lat1, lon1, lat2, lon2 float64) float64 {
 	toRad := func(deg float64) float64 { return deg * math.Pi / 180.0 }
 	dLat := toRad(lat2 - lat1)

--- a/pkg/traffic/waypoints.go
+++ b/pkg/traffic/waypoints.go
@@ -4,9 +4,7 @@
 package traffic
 
 import (
-	"math"
-
-	"github.com/mrlm-net/simconnect/pkg/convert"
+	"github.com/mrlm-net/simconnect/pkg/calc"
 	"github.com/mrlm-net/simconnect/pkg/types"
 )
 
@@ -97,22 +95,12 @@ func ClimbWaypoint(lat, lon, altAGL, ktsSpeed, throttlePct float64) types.SIMCON
 // Append these directly after a LineupWaypoint to complete a full departure
 // sequence: [PushbackWaypoint] [TaxiWaypoint...] [LineupWaypoint] [TakeoffClimb...]
 func TakeoffClimb(rwyLat, rwyLon, hdgDeg float64) []types.SIMCONNECT_DATA_WAYPOINT {
-	c1Lat, c1Lon := ahead(rwyLat, rwyLon, hdgDeg, 2778)  // 1.5 nm
-	c2Lat, c2Lon := ahead(rwyLat, rwyLon, hdgDeg, 9260)  // 5 nm
-	c3Lat, c3Lon := ahead(rwyLat, rwyLon, hdgDeg, 22224) // 12 nm
+	c1Lat, c1Lon := calc.DisplaceByHeading(rwyLat, rwyLon, hdgDeg, 2778)  // 1.5 nm
+	c2Lat, c2Lon := calc.DisplaceByHeading(rwyLat, rwyLon, hdgDeg, 9260)  // 5 nm
+	c3Lat, c3Lon := calc.DisplaceByHeading(rwyLat, rwyLon, hdgDeg, 22224) // 12 nm
 	return []types.SIMCONNECT_DATA_WAYPOINT{
 		ClimbWaypoint(c1Lat, c1Lon, 1500, 200, 100),
 		ClimbWaypoint(c2Lat, c2Lon, 4000, 240, 90),
 		ClimbWaypoint(c3Lat, c3Lon, 9000, 280, 85),
 	}
-}
-
-// ahead returns the lat/lon displaced from (lat, lon) by the given distance in
-// meters along heading hdgDeg. Uses convert.OffsetToLatLon under the hood.
-func ahead(lat, lon, hdgDeg, meters float64) (float64, float64) {
-	rad := hdgDeg * math.Pi / 180
-	return convert.OffsetToLatLon(lat, lon,
-		meters*math.Sin(rad), // east component (X)
-		meters*math.Cos(rad), // north component (Z)
-	)
 }


### PR DESCRIPTION
## Summary
- Move `HaversineMeters` godoc comment to directly precede `func HaversineMeters`
- Add a separate godoc comment for the `earthRadiusM` const directly above its declaration
- Confirmed `bearing.go` and `displace.go` already have correctly placed godoc comments

## Test plan
- [x] `go fmt ./pkg/calc/...` passes
- [x] `go vet -unsafeptr=false ./pkg/calc/...` passes
- [x] `go test ./pkg/calc/...` passes
- [x] `go doc github.com/mrlm-net/simconnect/pkg/calc HaversineMeters` renders the correct description

Closes #216