### PR TITLE
feat(input-events): add MSFS 2024 Input Event API

### DIFF
--- a/internal/simconnect/inputevent.go
+++ b/internal/simconnect/inputevent.go
@@ -1,0 +1,91 @@
+//go:build windows
+// +build windows
+
+package simconnect
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+// https://docs.flightsimulator.com/msfs2024/html/6_Programming_APIs/SimConnect/API_Reference/Events_And_Data/SimConnect_EnumerateInputEvents.htm
+func (sc *SimConnect) EnumerateInputEvents(requestID uint32) error {
+	procedure := sc.library.LoadProcedure("SimConnect_EnumerateInputEvents")
+
+	hresult, _, _ := procedure.Call(
+		sc.getConnection(),
+		uintptr(requestID),
+	)
+
+	if !isHRESULTSuccess(hresult) {
+		return fmt.Errorf("SimConnect_EnumerateInputEvents failed with HRESULT: 0x%08X", uint32(hresult))
+	}
+
+	return nil
+}
+
+// https://docs.flightsimulator.com/msfs2024/html/6_Programming_APIs/SimConnect/API_Reference/Events_And_Data/SimConnect_GetInputEvent.htm
+func (sc *SimConnect) GetInputEvent(requestID uint32, hash uint64) error {
+	procedure := sc.library.LoadProcedure("SimConnect_GetInputEvent")
+
+	hresult, _, _ := procedure.Call(
+		sc.getConnection(),
+		uintptr(requestID),
+		uintptr(hash),
+	)
+
+	if !isHRESULTSuccess(hresult) {
+		return fmt.Errorf("SimConnect_GetInputEvent failed with HRESULT: 0x%08X", uint32(hresult))
+	}
+
+	return nil
+}
+
+// https://docs.flightsimulator.com/msfs2024/html/6_Programming_APIs/SimConnect/API_Reference/Events_And_Data/SimConnect_SetInputEvent.htm
+func (sc *SimConnect) SetInputEvent(hash uint64, value unsafe.Pointer) error {
+	procedure := sc.library.LoadProcedure("SimConnect_SetInputEvent")
+
+	hresult, _, _ := procedure.Call(
+		sc.getConnection(),
+		uintptr(hash),
+		uintptr(value),
+	)
+
+	if !isHRESULTSuccess(hresult) {
+		return fmt.Errorf("SimConnect_SetInputEvent failed with HRESULT: 0x%08X", uint32(hresult))
+	}
+
+	return nil
+}
+
+// https://docs.flightsimulator.com/msfs2024/html/6_Programming_APIs/SimConnect/API_Reference/Events_And_Data/SimConnect_SubscribeInputEvent.htm
+func (sc *SimConnect) SubscribeInputEvent(hash uint64) error {
+	procedure := sc.library.LoadProcedure("SimConnect_SubscribeInputEvent")
+
+	hresult, _, _ := procedure.Call(
+		sc.getConnection(),
+		uintptr(hash),
+	)
+
+	if !isHRESULTSuccess(hresult) {
+		return fmt.Errorf("SimConnect_SubscribeInputEvent failed with HRESULT: 0x%08X", uint32(hresult))
+	}
+
+	return nil
+}
+
+// https://docs.flightsimulator.com/msfs2024/html/6_Programming_APIs/SimConnect/API_Reference/Events_And_Data/SimConnect_UnsubscribeInputEvent.htm
+func (sc *SimConnect) UnsubscribeInputEvent(hash uint64) error {
+	procedure := sc.library.LoadProcedure("SimConnect_UnsubscribeInputEvent")
+
+	hresult, _, _ := procedure.Call(
+		sc.getConnection(),
+		uintptr(hash),
+	)
+
+	if !isHRESULTSuccess(hresult) {
+		return fmt.Errorf("SimConnect_UnsubscribeInputEvent failed with HRESULT: 0x%08X", uint32(hresult))
+	}
+
+	return nil
+}

--- a/internal/simconnect/main.go
+++ b/internal/simconnect/main.go
@@ -84,6 +84,13 @@ type API interface {
 	ClearNotificationGroup(groupID uint32) error
 	RequestNotificationGroup(groupID uint32, dwReserved uint32, flags uint32) error
 	SetNotificationGroupPriority(groupID uint32, priority uint32) error
+
+	// Input Event API (MSFS 2024 only)
+	EnumerateInputEvents(requestID uint32) error
+	GetInputEvent(requestID uint32, hash uint64) error
+	SetInputEvent(hash uint64, value unsafe.Pointer) error
+	SubscribeInputEvent(hash uint64) error
+	UnsubscribeInputEvent(hash uint64) error
 }
 
 func (sc *SimConnect) getConnection() uintptr {

--- a/pkg/engine/client.go
+++ b/pkg/engine/client.go
@@ -27,6 +27,14 @@ type Client interface {
 	// UnsubscribeFromFlowEvent cancels the active flow event subscription (MSFS 2024 only).
 	UnsubscribeFromFlowEvent() error
 
+	// Input Event API (MSFS 2024 only)
+	EnumerateInputEvents(requestID uint32) error
+	GetInputEvent(requestID uint32, hash uint64) error
+	SetInputEventDouble(hash uint64, value float64) error
+	SetInputEventString(hash uint64, value string) error
+	SubscribeInputEvent(hash uint64) error
+	UnsubscribeInputEvent(hash uint64) error
+
 	AddToDataDefinition(definitionID uint32, datumName string, unitsName string, datumType types.SIMCONNECT_DATATYPE, epsilon float32, datumID uint32) error
 	RequestDataOnSimObject(requestID uint32, definitionID uint32, objectID uint32, period types.SIMCONNECT_PERIOD, flags types.SIMCONNECT_DATA_REQUEST_FLAG, origin uint32, interval uint32, limit uint32) error
 	RequestDataOnSimObjectType(requestID uint32, definitionID uint32, dwRadiusMeters uint32, objectType types.SIMCONNECT_SIMOBJECT_TYPE) error

--- a/pkg/engine/inputevent.go
+++ b/pkg/engine/inputevent.go
@@ -1,0 +1,80 @@
+//go:build windows
+// +build windows
+
+package engine
+
+import (
+	"encoding/binary"
+	"math"
+	"unsafe"
+
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+func (e *Engine) EnumerateInputEvents(requestID uint32) error {
+	return e.api.EnumerateInputEvents(requestID)
+}
+
+func (e *Engine) GetInputEvent(requestID uint32, hash uint64) error {
+	return e.api.GetInputEvent(requestID, hash)
+}
+
+// SetInputEventDouble sets a DOUBLE-typed input event value.
+// The float64 is stack-allocated; its address is valid for the duration of the synchronous DLL call.
+func (e *Engine) SetInputEventDouble(hash uint64, value float64) error {
+	return e.api.SetInputEvent(hash, unsafe.Pointer(&value))
+}
+
+// SetInputEventString sets a STRING-typed input event value.
+// The value is copied into a null-terminated [260]byte buffer before the call.
+func (e *Engine) SetInputEventString(hash uint64, value string) error {
+	var buf [260]byte
+	copy(buf[:], value)
+	return e.api.SetInputEvent(hash, unsafe.Pointer(&buf[0]))
+}
+
+func (e *Engine) SubscribeInputEvent(hash uint64) error {
+	return e.api.SubscribeInputEvent(hash)
+}
+
+func (e *Engine) UnsubscribeInputEvent(hash uint64) error {
+	return e.api.UnsubscribeInputEvent(hash)
+}
+
+// InputEventValueAsFloat64 extracts the float64 value from a GET_INPUT_EVENT receive struct.
+// Returns (0, false) if Type is not SIMCONNECT_INPUT_EVENT_TYPE_DOUBLE.
+func InputEventValueAsFloat64(recv *types.SIMCONNECT_RECV_GET_INPUT_EVENT) (float64, bool) {
+	if recv.Type != types.SIMCONNECT_INPUT_EVENT_TYPE_DOUBLE {
+		return 0, false
+	}
+	bits := binary.LittleEndian.Uint64(recv.Value[:8])
+	return math.Float64frombits(bits), true
+}
+
+// InputEventValueAsString extracts the string value from a GET_INPUT_EVENT receive struct.
+// Returns ("", false) if Type is not SIMCONNECT_INPUT_EVENT_TYPE_STRING.
+func InputEventValueAsString(recv *types.SIMCONNECT_RECV_GET_INPUT_EVENT) (string, bool) {
+	if recv.Type != types.SIMCONNECT_INPUT_EVENT_TYPE_STRING {
+		return "", false
+	}
+	return BytesToString(recv.Value[:]), true
+}
+
+// SubscribeInputEventValueAsFloat64 extracts the float64 value from a SUBSCRIBE_INPUT_EVENT receive struct.
+// Returns (0, false) if EType is not SIMCONNECT_INPUT_EVENT_TYPE_DOUBLE.
+func SubscribeInputEventValueAsFloat64(recv *types.SIMCONNECT_RECV_SUBSCRIBE_INPUT_EVENT) (float64, bool) {
+	if recv.EType != types.SIMCONNECT_INPUT_EVENT_TYPE_DOUBLE {
+		return 0, false
+	}
+	bits := binary.LittleEndian.Uint64(recv.Value[:8])
+	return math.Float64frombits(bits), true
+}
+
+// SubscribeInputEventValueAsString extracts the string value from a SUBSCRIBE_INPUT_EVENT receive struct.
+// Returns ("", false) if EType is not SIMCONNECT_INPUT_EVENT_TYPE_STRING.
+func SubscribeInputEventValueAsString(recv *types.SIMCONNECT_RECV_SUBSCRIBE_INPUT_EVENT) (string, bool) {
+	if recv.EType != types.SIMCONNECT_INPUT_EVENT_TYPE_STRING {
+		return "", false
+	}
+	return BytesToString(recv.Value[:]), true
+}

--- a/pkg/engine/inputevent.go
+++ b/pkg/engine/inputevent.go
@@ -26,10 +26,11 @@ func (e *Engine) SetInputEventDouble(hash uint64, value float64) error {
 }
 
 // SetInputEventString sets a STRING-typed input event value.
-// The value is copied into a null-terminated [260]byte buffer before the call.
+// value is copied into a 260-byte null-terminated buffer. Strings longer than 259
+// bytes are silently truncated to 259 bytes to preserve the null terminator at buf[259].
 func (e *Engine) SetInputEventString(hash uint64, value string) error {
 	var buf [260]byte
-	copy(buf[:], value)
+	copy(buf[:259], value) // reserve buf[259] as null terminator
 	return e.api.SetInputEvent(hash, unsafe.Pointer(&buf[0]))
 }
 

--- a/pkg/engine/message.go
+++ b/pkg/engine/message.go
@@ -232,3 +232,33 @@ func (m *Message) AsFlowEvent() *types.SIMCONNECT_RECV_FLOW_EVENT {
 	}
 	return (*types.SIMCONNECT_RECV_FLOW_EVENT)(unsafe.Pointer(m.SIMCONNECT_RECV))
 }
+
+// AsEnumerateInputEvents casts the message to SIMCONNECT_RECV_ENUMERATE_INPUT_EVENTS.
+// Returns nil if the message is not an enumerate input events response.
+// Note: MSFS 2024 only.
+func (m *Message) AsEnumerateInputEvents() *types.SIMCONNECT_RECV_ENUMERATE_INPUT_EVENTS {
+	if types.SIMCONNECT_RECV_ID(m.DwID) != types.SIMCONNECT_RECV_ID_ENUMERATE_INPUT_EVENTS {
+		return nil
+	}
+	return (*types.SIMCONNECT_RECV_ENUMERATE_INPUT_EVENTS)(unsafe.Pointer(m.SIMCONNECT_RECV))
+}
+
+// AsGetInputEvent casts the message to SIMCONNECT_RECV_GET_INPUT_EVENT.
+// Returns nil if the message is not a get input event response.
+// Note: MSFS 2024 only.
+func (m *Message) AsGetInputEvent() *types.SIMCONNECT_RECV_GET_INPUT_EVENT {
+	if types.SIMCONNECT_RECV_ID(m.DwID) != types.SIMCONNECT_RECV_ID_GET_INPUT_EVENT {
+		return nil
+	}
+	return (*types.SIMCONNECT_RECV_GET_INPUT_EVENT)(unsafe.Pointer(m.SIMCONNECT_RECV))
+}
+
+// AsSubscribeInputEvent casts the message to SIMCONNECT_RECV_SUBSCRIBE_INPUT_EVENT.
+// Returns nil if the message is not a subscribe input event notification.
+// Note: MSFS 2024 only.
+func (m *Message) AsSubscribeInputEvent() *types.SIMCONNECT_RECV_SUBSCRIBE_INPUT_EVENT {
+	if types.SIMCONNECT_RECV_ID(m.DwID) != types.SIMCONNECT_RECV_ID_SUBSCRIBE_INPUT_EVENT {
+		return nil
+	}
+	return (*types.SIMCONNECT_RECV_SUBSCRIBE_INPUT_EVENT)(unsafe.Pointer(m.SIMCONNECT_RECV))
+}


### PR DESCRIPTION
## Summary

Implements the MSFS 2024 Input Event API across all SDK layers.

**Type fixes (#145)**
- `SIMCONNECT_RECV_GET_INPUT_EVENT.Value`: `unsafe.Pointer` → `[260]byte`
- `SIMCONNECT_RECV_SUBSCRIBE_INPUT_EVENT`: restructured to flat fields (SimConnect.h `#pragma pack(1)` confirmed — `Hash` at wire offset 12, Go embedding would incorrectly place it at offset 16)
- Added `SIMCONNECT_RECV_ENUMERATE_INPUT_EVENTS` (was missing)

**DLL bindings (#146)**
- `internal/simconnect/inputevent.go`: five `SimConnect_*` bindings following `LoadProcedure`/`Call`/HRESULT pattern

**Engine wrappers + extractors (#147)**
- `pkg/engine/inputevent.go`: six typed engine methods including `SetInputEventDouble`/`SetInputEventString` (no `unsafe.Pointer` on public `Client` interface)
- Package-level extractors: `InputEventValueAsFloat64`, `InputEventValueAsString`, `SubscribeInputEventValueAsFloat64`, `SubscribeInputEventValueAsString`

**Message helpers (#148)**
- `AsEnumerateInputEvents()`, `AsGetInputEvent()`, `AsSubscribeInputEvent()` on `Message`

Closes #145
Closes #146
Closes #147
Closes #148
Part of #143