### PR TITLE
feat(datasets): implement aircraft, environment, simulator, and objects dataset packages

### DIFF
--- a/docs/usage-datasets.md
+++ b/docs/usage-datasets.md
@@ -1,0 +1,237 @@
+---
+title: "Using Datasets"
+description: "Pre-built dataset constructors for aircraft, environment, simulator, objects, and traffic data."
+order: 4
+---
+
+# Using Datasets
+
+The `pkg/datasets` sub-packages provide ready-made `DataSet` definitions paired with companion Go structs. Instead of building data definitions field by field with `AddToDataDefinition`, you pass a constructor's return value to `RegisterDataset` and use `CastDataAs[T]` to decode incoming messages directly into the companion struct.
+
+## How It Works
+
+Every dataset package exposes two things:
+
+1. A **constructor** (`New*Dataset()`) that returns `*datasets.DataSet` — a slice of `DataDefinition` entries that `RegisterDataset` feeds to SimConnect.
+2. A **companion struct** (e.g., `PositionDataset`) whose fields map 1-to-1, in order, to those definitions. Pass the struct type to `CastDataAs[T]` to decode a received message.
+
+```go
+import (
+    "github.com/mrlm-net/simconnect/pkg/datasets/aircraft"
+    "github.com/mrlm-net/simconnect/pkg/engine"
+    "github.com/mrlm-net/simconnect/pkg/types"
+)
+
+const (
+    PosDefID = 1000
+    PosReqID = 1001
+)
+
+// Register the dataset once, after connecting
+client.RegisterDataset(PosDefID, aircraft.NewPositionDataset())
+
+client.RequestDataOnSimObject(
+    PosReqID, PosDefID,
+    types.SIMCONNECT_OBJECT_ID_USER,
+    types.SIMCONNECT_PERIOD_SECOND,
+    types.SIMCONNECT_DATA_REQUEST_FLAG_CHANGED,
+    0, 0, 0,
+)
+
+// Decode in the message loop
+for msg := range client.Stream() {
+    if types.SIMCONNECT_RECV_ID(msg.DwID) == types.SIMCONNECT_RECV_ID_SIMOBJECT_DATA {
+        data := msg.AsSimObjectData()
+        if data.DwRequestID == PosReqID {
+            pos := engine.CastDataAs[aircraft.PositionDataset](&data.DwData)
+            fmt.Printf("lat=%.4f lon=%.4f alt=%.0fft\n", pos.Latitude, pos.Longitude, pos.Altitude)
+        }
+    }
+}
+```
+
+The same pattern applies to every dataset in this document.
+
+## aircraft
+
+Import path: `github.com/mrlm-net/simconnect/pkg/datasets/aircraft`
+
+| Constructor | Companion Struct | Data |
+|---|---|---|
+| `NewPositionDataset()` | `PositionDataset` | Latitude, longitude, altitude, pitch, bank, true heading, vertical speed, ground speed |
+| `NewAirspeedDataset()` | `AirspeedDataset` | IAS, TAS, Mach number |
+| `NewEngineDataset()` | `EngineDataset` | Engine RPM (4 engines), throttle lower limit, total fuel quantity, fuel flow for engine 1 |
+| `NewControlSurfacesDataset()` | `ControlSurfacesDataset` | Aileron, elevator, rudder position; flaps handle index; gear handle position |
+
+### PositionDataset fields
+
+| Field | SimVar | Unit |
+|---|---|---|
+| `Latitude` | `PLANE LATITUDE` | degrees |
+| `Longitude` | `PLANE LONGITUDE` | degrees |
+| `Altitude` | `PLANE ALTITUDE` | feet |
+| `Pitch` | `PLANE PITCH DEGREES` | degrees |
+| `Bank` | `PLANE BANK DEGREES` | degrees |
+| `HeadingTrue` | `PLANE HEADING DEGREES TRUE` | degrees |
+| `VerticalSpeed` | `VERTICAL SPEED` | feet per minute |
+| `GroundSpeed` | `GROUND VELOCITY` | knots |
+
+### AirspeedDataset fields
+
+| Field | SimVar | Unit |
+|---|---|---|
+| `AirspeedIndicated` | `AIRSPEED INDICATED` | knots |
+| `AirspeedTrue` | `AIRSPEED TRUE` | knots |
+| `AirspeedMach` | `AIRSPEED MACH` | mach |
+
+### EngineDataset fields
+
+| Field | SimVar | Unit |
+|---|---|---|
+| `EngRPM1` | `ENG RPM:1` | rpm |
+| `EngRPM2` | `ENG RPM:2` | rpm |
+| `EngRPM3` | `ENG RPM:3` | rpm |
+| `EngRPM4` | `ENG RPM:4` | rpm |
+| `ThrottleLowerLimit` | `THROTTLE LOWER LIMIT` | percent |
+| `FuelTotalQuantity` | `FUEL TOTAL QUANTITY` | gallons |
+| `FuelFlowGPH1` | `ENG FUEL FLOW GPH:1` | gallons per hour |
+
+### ControlSurfacesDataset fields
+
+| Field | SimVar | Unit |
+|---|---|---|
+| `AileronPosition` | `AILERON POSITION` | position |
+| `ElevatorPosition` | `ELEVATOR POSITION` | position |
+| `RudderPosition` | `RUDDER POSITION` | position |
+| `FlapsHandleIndex` | `FLAPS HANDLE INDEX` | number |
+| `GearHandlePos` | `GEAR HANDLE POSITION` | bool (0.0=up, 1.0=down) |
+
+## environment
+
+Import path: `github.com/mrlm-net/simconnect/pkg/datasets/environment`
+
+| Constructor | Companion Struct | Data |
+|---|---|---|
+| `NewWeatherDataset()` | `WeatherDataset` | Temperature, pressure, wind direction and velocity, visibility, precipitation rate and state |
+| `NewTimeDataset()` | `TimeDataset` | Local time, Zulu time, simulation rate, Zulu day/month/year |
+
+### WeatherDataset fields
+
+| Field | SimVar | Unit |
+|---|---|---|
+| `Temperature` | `AMBIENT TEMPERATURE` | celsius |
+| `Pressure` | `AMBIENT PRESSURE` | millibars |
+| `WindDirection` | `AMBIENT WIND DIRECTION` | degrees |
+| `WindVelocity` | `AMBIENT WIND VELOCITY` | knots |
+| `Visibility` | `AMBIENT VISIBILITY` | meters |
+| `PrecipRate` | `AMBIENT PRECIP RATE` | millimeters of water |
+| `PrecipState` | `AMBIENT PRECIP STATE` | mask (2=None, 4=Rain, 8=Snow) |
+
+> **Note:** `PrecipState` is stored as `float64` to preserve struct alignment. Cast to `uint32` before bit-testing: `state := uint32(w.PrecipState)`.
+
+### TimeDataset fields
+
+| Field | SimVar | Unit |
+|---|---|---|
+| `LocalTime` | `LOCAL TIME` | seconds since midnight |
+| `ZuluTime` | `ZULU TIME` | seconds since midnight |
+| `SimulationRate` | `SIMULATION RATE` | number |
+| `ZuluDay` | `ZULU DAY OF MONTH` | number |
+| `ZuluMonth` | `ZULU MONTH OF YEAR` | number |
+| `ZuluYear` | `ZULU YEAR` | number |
+
+## simulator
+
+Import path: `github.com/mrlm-net/simconnect/pkg/datasets/simulator`
+
+| Constructor | Companion Struct | Data |
+|---|---|---|
+| `NewSimStateDataset()` | `SimStateDataset` | Sim on ground, surface type, user sim flag, total weight, crash flag |
+| `NewCameraDataset()` | `CameraDataset` | Camera state, camera substate, camera view type index |
+
+### SimStateDataset fields
+
+| Field | SimVar | Unit |
+|---|---|---|
+| `SimOnGround` | `SIM ON GROUND` | bool (as float64) |
+| `SurfaceType` | `SURFACE TYPE` | enum |
+| `IsUserSim` | `IS USER SIM` | bool (as float64) |
+| `TotalWeight` | `TOTAL WEIGHT` | pounds |
+| `CrashFlag` | `CRASH FLAG` | enum bitmask |
+
+> **Note:** `CrashFlag` is stored as `float64`. Cast to `uint32` before bit-testing.
+
+### CameraDataset fields
+
+| Field | SimVar | Unit |
+|---|---|---|
+| `CameraState` | `CAMERA STATE` | enum |
+| `CameraSubstate` | `CAMERA SUBSTATE` | enum |
+| `CameraViewType` | `CAMERA VIEW TYPE INDEX:0` | number |
+
+Camera state values correspond to the constants in `pkg/manager/state-enums.go` (e.g., `CameraStateCockpit = 2`, `CameraStateDrone = 4`). See [Manager Usage](usage-manager.md#camera-states) for the full list.
+
+## objects
+
+Import path: `github.com/mrlm-net/simconnect/pkg/datasets/objects`
+
+| Constructor | Companion Struct | Data |
+|---|---|---|
+| `NewSimObjectPositionDataset()` | `SimObjectPositionDataset` | Latitude, longitude, altitude, pitch, bank, true heading, ground speed, sim-on-ground flag |
+
+### SimObjectPositionDataset fields
+
+| Field | SimVar | Unit |
+|---|---|---|
+| `Latitude` | `PLANE LATITUDE` | degrees |
+| `Longitude` | `PLANE LONGITUDE` | degrees |
+| `Altitude` | `PLANE ALTITUDE` | feet |
+| `Pitch` | `PLANE PITCH DEGREES` | degrees |
+| `Bank` | `PLANE BANK DEGREES` | degrees |
+| `HeadingTrue` | `PLANE HEADING DEGREES TRUE` | degrees |
+| `GroundSpeed` | `GROUND VELOCITY` | knots |
+| `SimOnGround` | `SIM ON GROUND` | bool (as float64) |
+
+Use this dataset with `RequestDataOnSimObjectType` to query all nearby objects in a single request:
+
+```go
+import "github.com/mrlm-net/simconnect/pkg/datasets/objects"
+
+const (
+    ObjDefID = 2000
+    ObjReqID = 2001
+)
+
+client.RegisterDataset(ObjDefID, objects.NewSimObjectPositionDataset())
+
+client.RequestDataOnSimObjectType(
+    ObjReqID,
+    ObjDefID,
+    25000, // 25 km radius
+    types.SIMCONNECT_SIMOBJECT_TYPE_AIRCRAFT,
+)
+
+for msg := range client.Stream() {
+    if types.SIMCONNECT_RECV_ID(msg.DwID) == types.SIMCONNECT_RECV_ID_SIMOBJECT_DATA_BYTYPE {
+        data := msg.AsSimObjectDataByType()
+        if data.DwRequestID == ObjReqID {
+            obj := engine.CastDataAs[objects.SimObjectPositionDataset](&data.DwData)
+            fmt.Printf("objectID=%d lat=%.4f lon=%.4f\n", data.DwObjectID, obj.Latitude, obj.Longitude)
+        }
+    }
+}
+```
+
+## traffic
+
+Import path: `github.com/mrlm-net/simconnect/pkg/datasets/traffic`
+
+| Constructor | Companion Struct | Data |
+|---|---|---|
+| `NewAircraftDataset()` | `AircraftDataset` | Title, category, livery, position, attitude, speed, surface state, ATC identifiers, wing span |
+
+This is the original reference implementation. `AircraftDataset` combines identity strings (`[128]byte`, `[32]byte`) with float64 motion fields and int32 boolean/enum fields, demonstrating the mixed-type pattern for datasets that include SimConnect string variables.
+
+## Alignment note
+
+All numeric fields in the companion structs use `float64`, even for variables that logically carry boolean or enum values. This is intentional: using a uniform 8-byte type for every numeric field eliminates Go struct padding between fields. The byte layout of the struct must match the byte layout that SimConnect writes into the data block, and that layout is determined entirely by the order and type of entries in the `DataSet.Definitions` slice. If you add, remove, or reorder fields in either the struct or the constructor, `CastDataAs[T]` will silently misalign — the compiler cannot catch this.

--- a/pkg/datasets/aircraft/main.go
+++ b/pkg/datasets/aircraft/main.go
@@ -2,3 +2,106 @@
 // +build windows
 
 package aircraft
+
+import (
+	"github.com/mrlm-net/simconnect/pkg/datasets"
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+// NewPositionDataset returns a dataset for aircraft spatial position and orientation.
+func NewPositionDataset() *datasets.DataSet {
+	return &datasets.DataSet{
+		Definitions: []datasets.DataDefinition{
+			{Name: "PLANE LATITUDE", Unit: "degrees", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "PLANE LONGITUDE", Unit: "degrees", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "PLANE ALTITUDE", Unit: "feet", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "PLANE PITCH DEGREES", Unit: "degrees", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "PLANE BANK DEGREES", Unit: "degrees", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "PLANE HEADING DEGREES TRUE", Unit: "degrees", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "VERTICAL SPEED", Unit: "feet per minute", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "GROUND VELOCITY", Unit: "knots", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+		},
+	}
+}
+
+// PositionDataset is the companion struct for NewPositionDataset.
+// Fields must remain in the same order as the DataDefinitions slice.
+type PositionDataset struct {
+	Latitude      float64
+	Longitude     float64
+	Altitude      float64
+	Pitch         float64
+	Bank          float64
+	HeadingTrue   float64
+	VerticalSpeed float64
+	GroundSpeed   float64
+}
+
+// NewAirspeedDataset returns a dataset for aircraft airspeed indicators.
+func NewAirspeedDataset() *datasets.DataSet {
+	return &datasets.DataSet{
+		Definitions: []datasets.DataDefinition{
+			{Name: "AIRSPEED INDICATED", Unit: "knots", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "AIRSPEED TRUE", Unit: "knots", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "AIRSPEED MACH", Unit: "mach", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+		},
+	}
+}
+
+// AirspeedDataset is the companion struct for NewAirspeedDataset.
+// Fields must remain in the same order as the DataDefinitions slice.
+type AirspeedDataset struct {
+	AirspeedIndicated float64
+	AirspeedTrue      float64
+	AirspeedMach      float64
+}
+
+// NewEngineDataset returns a dataset for engine state across up to four engines and fuel.
+func NewEngineDataset() *datasets.DataSet {
+	return &datasets.DataSet{
+		Definitions: []datasets.DataDefinition{
+			{Name: "ENG RPM:1", Unit: "rpm", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "ENG RPM:2", Unit: "rpm", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "ENG RPM:3", Unit: "rpm", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "ENG RPM:4", Unit: "rpm", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "THROTTLE LOWER LIMIT", Unit: "percent", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "FUEL TOTAL QUANTITY", Unit: "gallons", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "ENG FUEL FLOW GPH:1", Unit: "gallons per hour", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+		},
+	}
+}
+
+// EngineDataset is the companion struct for NewEngineDataset.
+// Fields must remain in the same order as the DataDefinitions slice.
+type EngineDataset struct {
+	EngRPM1            float64
+	EngRPM2            float64
+	EngRPM3            float64
+	EngRPM4            float64
+	ThrottleLowerLimit float64
+	FuelTotalQuantity  float64
+	FuelFlowGPH1       float64
+}
+
+// NewControlSurfacesDataset returns a dataset for flight control surface positions.
+func NewControlSurfacesDataset() *datasets.DataSet {
+	return &datasets.DataSet{
+		Definitions: []datasets.DataDefinition{
+			{Name: "AILERON POSITION", Unit: "position", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "ELEVATOR POSITION", Unit: "position", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "RUDDER POSITION", Unit: "position", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "FLAPS HANDLE INDEX", Unit: "number", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "GEAR HANDLE POSITION", Unit: "bool", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+		},
+	}
+}
+
+// ControlSurfacesDataset is the companion struct for NewControlSurfacesDataset.
+// Fields must remain in the same order as the DataDefinitions slice.
+type ControlSurfacesDataset struct {
+	AileronPosition  float64
+	ElevatorPosition float64
+	RudderPosition   float64
+	FlapsHandleIndex float64
+	GearHandlePos    float64
+}

--- a/pkg/datasets/aircraft/main.go
+++ b/pkg/datasets/aircraft/main.go
@@ -103,5 +103,5 @@ type ControlSurfacesDataset struct {
 	ElevatorPosition float64
 	RudderPosition   float64
 	FlapsHandleIndex float64
-	GearHandlePos    float64
+	GearHandlePos    float64 // 0.0=up, 1.0=down; not a continuous travel position
 }

--- a/pkg/datasets/environment/main.go
+++ b/pkg/datasets/environment/main.go
@@ -32,7 +32,7 @@ type WeatherDataset struct {
 	WindVelocity  float64
 	Visibility    float64
 	PrecipRate    float64
-	PrecipState   float64
+	PrecipState   float64 // bitmask: 2=None, 4=Rain, 8=Snow; cast to uint32 before bit-testing
 }
 
 // NewTimeDataset returns a dataset for simulation time and date variables.

--- a/pkg/datasets/environment/main.go
+++ b/pkg/datasets/environment/main.go
@@ -2,3 +2,60 @@
 // +build windows
 
 package environment
+
+import (
+	"github.com/mrlm-net/simconnect/pkg/datasets"
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+// NewWeatherDataset returns a dataset for ambient environmental and weather conditions.
+func NewWeatherDataset() *datasets.DataSet {
+	return &datasets.DataSet{
+		Definitions: []datasets.DataDefinition{
+			{Name: "AMBIENT TEMPERATURE", Unit: "celsius", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "AMBIENT PRESSURE", Unit: "millibars", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "AMBIENT WIND DIRECTION", Unit: "degrees", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "AMBIENT WIND VELOCITY", Unit: "knots", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "AMBIENT VISIBILITY", Unit: "meters", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "AMBIENT PRECIP RATE", Unit: "millimeters of water", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "AMBIENT PRECIP STATE", Unit: "mask", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+		},
+	}
+}
+
+// WeatherDataset is the companion struct for NewWeatherDataset.
+// Fields must remain in the same order as the DataDefinitions slice.
+type WeatherDataset struct {
+	Temperature   float64
+	Pressure      float64
+	WindDirection float64
+	WindVelocity  float64
+	Visibility    float64
+	PrecipRate    float64
+	PrecipState   float64
+}
+
+// NewTimeDataset returns a dataset for simulation time and date variables.
+func NewTimeDataset() *datasets.DataSet {
+	return &datasets.DataSet{
+		Definitions: []datasets.DataDefinition{
+			{Name: "LOCAL TIME", Unit: "seconds", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "ZULU TIME", Unit: "seconds", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "SIMULATION RATE", Unit: "number", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "ZULU DAY OF MONTH", Unit: "number", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "ZULU MONTH OF YEAR", Unit: "number", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "ZULU YEAR", Unit: "number", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+		},
+	}
+}
+
+// TimeDataset is the companion struct for NewTimeDataset.
+// Fields must remain in the same order as the DataDefinitions slice.
+type TimeDataset struct {
+	LocalTime      float64
+	ZuluTime       float64
+	SimulationRate float64
+	ZuluDay        float64
+	ZuluMonth      float64
+	ZuluYear       float64
+}

--- a/pkg/datasets/objects/main.go
+++ b/pkg/datasets/objects/main.go
@@ -2,3 +2,37 @@
 // +build windows
 
 package objects
+
+import (
+	"github.com/mrlm-net/simconnect/pkg/datasets"
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+// NewSimObjectPositionDataset returns a dataset for SimObject spatial position and ground state.
+func NewSimObjectPositionDataset() *datasets.DataSet {
+	return &datasets.DataSet{
+		Definitions: []datasets.DataDefinition{
+			{Name: "PLANE LATITUDE", Unit: "degrees", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "PLANE LONGITUDE", Unit: "degrees", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "PLANE ALTITUDE", Unit: "feet", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "PLANE PITCH DEGREES", Unit: "degrees", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "PLANE BANK DEGREES", Unit: "degrees", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "PLANE HEADING DEGREES TRUE", Unit: "degrees", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "GROUND VELOCITY", Unit: "knots", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "SIM ON GROUND", Unit: "bool", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+		},
+	}
+}
+
+// SimObjectPositionDataset is the companion struct for NewSimObjectPositionDataset.
+// Fields must remain in the same order as the DataDefinitions slice.
+type SimObjectPositionDataset struct {
+	Latitude    float64
+	Longitude   float64
+	Altitude    float64
+	Pitch       float64
+	Bank        float64
+	HeadingTrue float64
+	GroundSpeed float64
+	SimOnGround float64
+}

--- a/pkg/datasets/simulator/main.go
+++ b/pkg/datasets/simulator/main.go
@@ -2,3 +2,50 @@
 // +build windows
 
 package simulator
+
+import (
+	"github.com/mrlm-net/simconnect/pkg/datasets"
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+// NewSimStateDataset returns a dataset for core simulator state variables.
+func NewSimStateDataset() *datasets.DataSet {
+	return &datasets.DataSet{
+		Definitions: []datasets.DataDefinition{
+			{Name: "SIM ON GROUND", Unit: "bool", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "SURFACE TYPE", Unit: "enum", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "IS USER SIM", Unit: "bool", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "TOTAL WEIGHT", Unit: "pounds", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "CRASH FLAG", Unit: "enum", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+		},
+	}
+}
+
+// SimStateDataset is the companion struct for NewSimStateDataset.
+// Fields must remain in the same order as the DataDefinitions slice.
+type SimStateDataset struct {
+	SimOnGround float64
+	SurfaceType float64
+	IsUserSim   float64
+	TotalWeight float64
+	CrashFlag   float64
+}
+
+// NewCameraDataset returns a dataset for camera and view state variables.
+func NewCameraDataset() *datasets.DataSet {
+	return &datasets.DataSet{
+		Definitions: []datasets.DataDefinition{
+			{Name: "CAMERA STATE", Unit: "enum", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "CAMERA SUBSTATE", Unit: "enum", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "CAMERA VIEW TYPE INDEX:0", Unit: "number", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+		},
+	}
+}
+
+// CameraDataset is the companion struct for NewCameraDataset.
+// Fields must remain in the same order as the DataDefinitions slice.
+type CameraDataset struct {
+	CameraState    float64
+	CameraSubstate float64
+	CameraViewType float64
+}

--- a/pkg/datasets/simulator/main.go
+++ b/pkg/datasets/simulator/main.go
@@ -28,7 +28,7 @@ type SimStateDataset struct {
 	SurfaceType float64
 	IsUserSim   float64
 	TotalWeight float64
-	CrashFlag   float64
+	CrashFlag   float64 // bitmask: cast to uint32 before bit-testing
 }
 
 // NewCameraDataset returns a dataset for camera and view state variables.


### PR DESCRIPTION
## Summary

Implements all four dataset packages as part of epic #120. Each package follows the established pattern from `pkg/datasets/traffic/main.go`: build-tagged constructor functions returning `*datasets.DataSet` with companion typed structs whose fields align exactly with the definition slice order.

- `pkg/datasets/aircraft/main.go` — 4 constructors: `NewPositionDataset`, `NewAirspeedDataset`, `NewEngineDataset`, `NewControlSurfacesDataset`
- `pkg/datasets/environment/main.go` — 2 constructors: `NewWeatherDataset`, `NewTimeDataset`
- `pkg/datasets/simulator/main.go` — 2 constructors: `NewSimStateDataset`, `NewCameraDataset`
- `pkg/datasets/objects/main.go` — 1 constructor: `NewSimObjectPositionDataset`

All numeric SimVars use `SIMCONNECT_DATATYPE_FLOAT64` exclusively, eliminating any struct padding bugs.

## Quality Gates

- `go build ./...` — PASS
- `go vet -unsafeptr=false ./...` — PASS

## Issues

Closes #121, Closes #122, Closes #123, Closes #124

Part of #120