### PR TITLE
docs(website): add 7 new guides and fix navigation ordering for v0.5.0

### DIFF
--- a/docs/client-data-area.md
+++ b/docs/client-data-area.md
@@ -1,7 +1,7 @@
 ---
 title: "Client Data Areas"
 description: "Using SimConnect Client Data Areas for inter-add-on shared memory communication."
-order: 5
+order: 6
 section: "client"
 ---
 

--- a/docs/config-client.md
+++ b/docs/config-client.md
@@ -1,7 +1,7 @@
 ---
 title: "Engine/Client Configuration"
 description: "Configuration options for the SimConnect engine client."
-order: 1
+order: 2
 section: "client"
 ---
 

--- a/docs/config-manager.md
+++ b/docs/config-manager.md
@@ -1,7 +1,7 @@
 ---
 title: "Manager Configuration"
 description: "Configuration options for the connection manager."
-order: 3
+order: 1
 section: "manager"
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,167 @@
+---
+title: "Getting Started"
+description: "Install the library and write your first Microsoft Flight Simulator connection."
+order: 1
+section: "client"
+---
+
+# Getting Started
+
+This guide walks you through installing the library, connecting to Microsoft Flight Simulator, and reading your first SimVar — from zero to live data in a few minutes.
+
+## Prerequisites
+
+- **Windows only.** SimConnect is a Windows-native DLL. The library will not compile on other platforms.
+- **Go 1.25+**
+- **Microsoft Flight Simulator 2020 or 2024** installed and running when you test your add-on.
+- **SimConnect.dll** — bundled with MSFS. The library auto-detects it from common SDK installation paths. You can also set the `SIMCONNECT_DLL` environment variable or pass `simconnect.ClientWithDLLPath(...)` to override detection.
+
+## Install
+
+```bash
+go get github.com/mrlm-net/simconnect
+```
+
+## Connect and Disconnect
+
+Every file that imports or calls SimConnect APIs must carry the `//go:build windows` build constraint. The DLL does not exist on other platforms and the Go toolchain will refuse to link without it.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+    "os"
+
+    "github.com/mrlm-net/simconnect"
+)
+
+func main() {
+    client := simconnect.NewClient("MyApp")
+
+    if err := client.Connect(); err != nil {
+        fmt.Fprintln(os.Stderr, "connect error:", err)
+        os.Exit(1)
+    }
+    defer client.Disconnect()
+
+    // Wait for the open acknowledgement before doing any work.
+    for msg := range client.Stream() {
+        if open := msg.AsOpen(); open != nil {
+            fmt.Println("connected to SimConnect")
+            break
+        }
+    }
+}
+```
+
+`simconnect.NewClient` accepts the application name that MSFS displays in its connection list. `Connect()` loads the DLL and opens a named-pipe channel to the simulator. `Disconnect()` cancels all in-flight work and closes the connection — the `defer` form is the correct pattern.
+
+## Read a SimVar
+
+Reading data from the simulator requires three steps: define the data structure, request it, and consume it from the message stream.
+
+### Step 1 — Define the data
+
+`AddToDataDefinition` binds a SimConnect variable name and unit to a definition ID. Call it once per field; the order of calls determines the field order in the struct you will cast the response into.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+    "os"
+
+    "github.com/mrlm-net/simconnect"
+    "github.com/mrlm-net/simconnect/pkg/engine"
+    "github.com/mrlm-net/simconnect/pkg/types"
+)
+
+// IDs can be any uint32 in the range 1–999,999,899.
+const (
+    PositionDefID uint32 = 1000
+    PositionReqID uint32 = 1001
+)
+
+// AircraftPosition must match the definition order and types exactly.
+type AircraftPosition struct {
+    Latitude  float64
+    Longitude float64
+    Altitude  float64
+}
+
+func main() {
+    client := simconnect.NewClient("MyApp")
+
+    if err := client.Connect(); err != nil {
+        fmt.Fprintln(os.Stderr, "connect error:", err)
+        os.Exit(1)
+    }
+    defer client.Disconnect()
+
+    // Register the three variables we want to read.
+    client.AddToDataDefinition(PositionDefID, "PLANE LATITUDE",  "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 0)
+    client.AddToDataDefinition(PositionDefID, "PLANE LONGITUDE", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 0)
+    client.AddToDataDefinition(PositionDefID, "PLANE ALTITUDE",  "feet",    types.SIMCONNECT_DATATYPE_FLOAT64, 0, 0)
+
+    // Request the data once for the user aircraft.
+    client.RequestDataOnSimObject(
+        PositionReqID,
+        PositionDefID,
+        types.SIMCONNECT_OBJECT_ID_USER,
+        types.SIMCONNECT_PERIOD_ONCE,
+        types.SIMCONNECT_DATA_REQUEST_FLAG_DEFAULT,
+        0, 0, 0,
+    )
+
+    // Read messages until we receive the response.
+    for msg := range client.Stream() {
+        switch types.SIMCONNECT_RECV_ID(msg.DwID) {
+
+        case types.SIMCONNECT_RECV_ID_SIMOBJECT_DATA:
+            data := msg.AsSimObjectData()
+            if data.DwRequestID != PositionReqID {
+                continue
+            }
+            pos := engine.CastDataAs[AircraftPosition](&data.DwData)
+            fmt.Printf("lat=%.4f lon=%.4f alt=%.0fft\n",
+                pos.Latitude, pos.Longitude, pos.Altitude)
+            return
+
+        case types.SIMCONNECT_RECV_ID_EXCEPTION:
+            ex := msg.AsException()
+            fmt.Fprintf(os.Stderr, "simconnect exception: %d\n", ex.DwException)
+            return
+        }
+    }
+}
+```
+
+### How the cast works
+
+`AsSimObjectData()` reinterprets the raw message bytes as `SIMCONNECT_RECV_SIMOBJECT_DATA`. The actual payload sits at `data.DwData`. `CastDataAs[T]` performs an unsafe pointer cast from that field to your struct — no allocation, no copy.
+
+The struct layout must match the definition order and types exactly:
+
+| `AddToDataDefinition` type | Go field type |
+|---|---|
+| `SIMCONNECT_DATATYPE_FLOAT64` | `float64` |
+| `SIMCONNECT_DATATYPE_FLOAT32` | `float32` |
+| `SIMCONNECT_DATATYPE_INT32` | `int32` |
+| `SIMCONNECT_DATATYPE_INT64` | `int64` |
+| `SIMCONNECT_DATATYPE_STRING256` | `[256]byte` |
+
+Use `engine.BytesToString(field[:])` to convert a fixed-size byte array to a Go string.
+
+> **Note:** `SIMCONNECT_PERIOD_ONCE` delivers a single response and stops. For continuous updates, use `SIMCONNECT_PERIOD_SECOND` or `SIMCONNECT_PERIOD_SIM_FRAME` with `SIMCONNECT_DATA_REQUEST_FLAG_CHANGED` to receive data only when a value changes.
+
+## Next Steps
+
+- [Configuration](config-client.md) — DLL path, heartbeat frequency, buffer size, logging
+- [Engine/Client Usage](usage-client.md) — Full API reference: events, facilities, AI traffic, flight plans
+- [Datasets](usage-datasets.md) — Pre-built variable sets for aircraft position, engine state, weather, and more
+- [Manager](config-manager.md) — Production-ready wrapper with auto-reconnect and structured state tracking

--- a/docs/guide-facilities.md
+++ b/docs/guide-facilities.md
@@ -1,0 +1,526 @@
+---
+title: "Facility Data"
+description: "Query airports, VORs, NDBs, and waypoints using the facility data API."
+order: 8
+section: "client"
+---
+
+# Facility Data
+
+SimConnect exposes navigation database information through the facility data API. You can look up individual airports by ICAO code, enumerate all VORs or NDBs in range, subscribe to facilities that enter or leave proximity, and pull sub-tree data such as parking spots, taxiways, and jetways.
+
+> **See also:** [Engine/Client Usage](usage-client.md) for the general client setup, connection lifecycle, and message dispatch loop that facility queries depend on.
+
+## Overview
+
+The facility API covers four top-level types:
+
+| Type | List constant | Description |
+|------|--------------|-------------|
+| Airport | `SIMCONNECT_FACILITY_LIST_AIRPORT` | Airports, heliports, seaports |
+| Waypoint | `SIMCONNECT_FACILITY_LIST_WAYPOINT` | Named enroute waypoints |
+| NDB | `SIMCONNECT_FACILITY_LIST_TYPE_NDB` | Non-Directional Beacons |
+| VOR | `SIMCONNECT_FACILITY_LIST_TYPE_VOR` | VHF Omnidirectional Ranges |
+
+These constants come from `pkg/types` as `SIMCONNECT_FACILITY_LIST_TYPE`.
+
+Facility data works through the same definition-and-request pattern used for SimObject data: you declare which fields you want, then issue a request. Responses arrive as one or more `SIMCONNECT_RECV_ID_FACILITY_DATA` messages, terminated by a `SIMCONNECT_RECV_ID_FACILITY_DATA_END` message.
+
+## Facility Definition Setup
+
+Before requesting facility data you must declare the fields you want to receive. Use `AddToFacilityDefinition` with string field names.
+
+```go
+//go:build windows
+
+client.AddToFacilityDefinition(3000, "OPEN AIRPORT")
+client.AddToFacilityDefinition(3000, "LATITUDE")
+client.AddToFacilityDefinition(3000, "LONGITUDE")
+client.AddToFacilityDefinition(3000, "ALTITUDE")
+client.AddToFacilityDefinition(3000, "ICAO")
+client.AddToFacilityDefinition(3000, "NAME")
+client.AddToFacilityDefinition(3000, "NAME64")
+client.AddToFacilityDefinition(3000, "CLOSE AIRPORT")
+```
+
+The `OPEN <TYPE>` / `CLOSE <TYPE>` sentinels mark the start and end of a facility block. They are required when building multi-level definitions (for example, an airport that also enumerates its parking spots or taxiways).
+
+**Signature:**
+
+```go
+//go:build windows
+
+func (e *Engine) AddToFacilityDefinition(definitionID uint32, fieldName string) error
+```
+
+### Using Pre-Built Facility Datasets
+
+The `pkg/datasets/facilities` package provides ready-made definitions for all facility sub-types. Use `RegisterFacilityDataset` instead of calling `AddToFacilityDefinition` manually.
+
+```go
+//go:build windows
+
+import "github.com/mrlm-net/simconnect/pkg/datasets/facilities"
+
+client.RegisterFacilityDataset(3000, facilities.NewAirportFacilityDataset())
+client.RegisterFacilityDataset(3001, facilities.NewRunwayFacilityDataset())
+client.RegisterFacilityDataset(3002, facilities.NewParkingFacilityDataset())
+client.RegisterFacilityDataset(3003, facilities.NewFrequencyFacilityDataset())
+```
+
+Available constructors:
+
+| Constructor | Fields included |
+|-------------|----------------|
+| `NewAirportFacilityDataset()` | Name, ICAO, region, position, tower, transition altitude, country, city |
+| `NewRunwayFacilityDataset()` | Dimensions, heading, surface type, lighting |
+| `NewParkingFacilityDataset()` | Parking spots, gates, ramps |
+| `NewFrequencyFacilityDataset()` | COM/NAV frequencies and types |
+| `NewTaxiPointFacilityDataset()` | Taxiway intersection points |
+| `NewTaxiPathFacilityDataset()` | Taxiway paths and routes |
+| `NewTaxiNameFacilityDataset()` | Taxiway names |
+| `NewHelipadFacilityDataset()` | Helipad location and properties |
+| `NewJetwayFacilityDataset()` | Jetway data |
+| `NewDepartureFacilityDataset()` | SID procedures |
+| `NewApproachFacilityDataset()` | Approach procedures |
+| `NewVORFacilityDataset()` | VOR navaid data |
+| `NewNDBFacilityDataset()` | NDB navaid data |
+| `NewWaypointFacilityDataset()` | Waypoint data |
+
+## Single Facility Request
+
+To retrieve data for a specific facility by ICAO code, use `RequestFacilityData`.
+
+**Signature:**
+
+```go
+//go:build windows
+
+func (e *Engine) RequestFacilityData(definitionID uint32, requestID uint32, icao string, region string) error
+```
+
+The `region` parameter is a two-character ICAO region code. Pass an empty string when the ICAO code is globally unique (most airports).
+
+### Example: Airport Lookup
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+
+    "github.com/mrlm-net/simconnect/pkg/engine"
+    "github.com/mrlm-net/simconnect/pkg/types"
+)
+
+type AirportData struct {
+    Latitude  float64
+    Longitude float64
+    Altitude  float64
+    ICAO      [8]byte
+    Name      [32]byte
+    Name64    [64]byte
+}
+
+const (
+    AirportDefID = 3000
+    AirportReqID = 123
+)
+
+func setupAirportDefinition(client *engine.Engine) {
+    client.AddToFacilityDefinition(AirportDefID, "OPEN AIRPORT")
+    client.AddToFacilityDefinition(AirportDefID, "LATITUDE")
+    client.AddToFacilityDefinition(AirportDefID, "LONGITUDE")
+    client.AddToFacilityDefinition(AirportDefID, "ALTITUDE")
+    client.AddToFacilityDefinition(AirportDefID, "ICAO")
+    client.AddToFacilityDefinition(AirportDefID, "NAME")
+    client.AddToFacilityDefinition(AirportDefID, "NAME64")
+    client.AddToFacilityDefinition(AirportDefID, "CLOSE AIRPORT")
+
+    // Request LKPR (Prague Vaclav Havel Airport), no region filter
+    client.RequestFacilityData(AirportDefID, AirportReqID, "LKPR", "")
+}
+
+func handleMessages(client *engine.Engine) {
+    for msg := range client.Stream() {
+        switch types.SIMCONNECT_RECV_ID(msg.DwID) {
+        case types.SIMCONNECT_RECV_ID_FACILITY_DATA:
+            fd := msg.AsFacilityData()
+            if fd.UserRequestId != AirportReqID {
+                continue
+            }
+            data := engine.CastDataAs[AirportData](&fd.Data)
+            fmt.Printf("Airport: %s\n", engine.BytesToString(data.ICAO[:]))
+            fmt.Printf("  Name:   %s\n", engine.BytesToString(data.Name64[:]))
+            fmt.Printf("  Lat:    %.6f\n", data.Latitude)
+            fmt.Printf("  Lon:    %.6f\n", data.Longitude)
+            fmt.Printf("  Alt:    %.1f m\n", data.Altitude)
+
+        case types.SIMCONNECT_RECV_ID_FACILITY_DATA_END:
+            fmt.Println("Facility data transfer complete.")
+        }
+    }
+}
+```
+
+The Go struct you pass to `CastDataAs` must mirror the field order and types declared in the definition. `float64` maps to `LATITUDE`, `LONGITUDE`, `ALTITUDE`; fixed-byte arrays map to string fields.
+
+### Using RequestFacilityDataEX1
+
+`RequestFacilityDataEX1` is an extended variant that accepts an explicit facility type byte. Use it when you need to disambiguate between facility types that share an ICAO code, or when targeting non-airport facilities.
+
+**Signature:**
+
+```go
+//go:build windows
+
+func (e *Engine) RequestFacilityDataEX1(definitionID uint32, requestID uint32, icao string, region string, facilityType byte) error
+```
+
+The `facilityType` parameter corresponds to `SIMCONNECT_FACILITY_DATA_TYPE` constants from `pkg/types`:
+
+| Constant | Value | Use |
+|----------|-------|-----|
+| `SIMCONNECT_FACILITY_DATA_AIRPORT` | 0 | Airport root record |
+| `SIMCONNECT_FACILITY_DATA_VOR` | 19 | VOR navaid |
+| `SIMCONNECT_FACILITY_DATA_NDB` | 20 | NDB navaid |
+| `SIMCONNECT_FACILITY_DATA_WAYPOINT` | 21 | Enroute waypoint |
+
+```go
+//go:build windows
+
+import "github.com/mrlm-net/simconnect/pkg/types"
+
+// Request VOR data explicitly
+client.RequestFacilityDataEX1(
+    VorDefID,
+    VorReqID,
+    "BCN",
+    "",
+    byte(types.SIMCONNECT_FACILITY_DATA_VOR),
+)
+```
+
+## Bulk Enumeration
+
+### RequestFacilitiesList
+
+Requests a snapshot of all known facilities of a given type. SimConnect returns results in batches; each batch is one `SIMCONNECT_RECV_ID_AIRPORT_LIST` (or equivalent) message.
+
+**Signature:**
+
+```go
+//go:build windows
+
+func (e *Engine) RequestFacilitiesList(definitionID uint32, listType types.SIMCONNECT_FACILITY_LIST_TYPE) error
+```
+
+### RequestAllFacilities
+
+`RequestAllFacilities` (MSFS 2024) is similar but takes an explicit request ID and does not require a prior definition. Use it for broad database dumps.
+
+**Signature:**
+
+```go
+//go:build windows
+
+func (e *Engine) RequestAllFacilities(listType types.SIMCONNECT_FACILITY_LIST_TYPE, requestID uint32) error
+```
+
+### Example: Enumerating All Airports
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+    "unsafe"
+
+    "github.com/mrlm-net/simconnect/pkg/engine"
+    "github.com/mrlm-net/simconnect/pkg/types"
+)
+
+const AllAirportsReqID = 2000
+
+func requestAllAirports(client *engine.Engine) {
+    client.RequestAllFacilities(types.SIMCONNECT_FACILITY_LIST_AIRPORT, AllAirportsReqID)
+}
+
+func handleAirportList(msg engine.Message) {
+    list := msg.AsAirportList()
+    if list == nil {
+        return
+    }
+
+    fmt.Printf("Packet %d of %d — %d airports\n",
+        list.DwEntryNumber, list.DwOutOf, list.DwArraySize)
+
+    if list.DwArraySize == 0 {
+        return
+    }
+
+    // Calculate actual wire stride from message size and entry count.
+    // Do not cast SIMCONNECT_DATA_FACILITY_AIRPORT directly — the Go struct
+    // has alignment padding that does not match the SimConnect wire format.
+    headerSize := unsafe.Sizeof(types.SIMCONNECT_RECV_FACILITIES_LIST{})
+    dataSize := uintptr(msg.Size) - headerSize
+    stride := dataSize / uintptr(list.DwArraySize)
+
+    // Derive field byte offsets for this simulator version.
+    var latOff, lonOff, altOff uintptr
+    switch stride {
+    case 33: // MSFS 2020: ident[6]+region[3]+3xfloat64
+        latOff, lonOff, altOff = 9, 17, 25
+    case 36, 40, 41: // MSFS 2024: ident[9]+region[3]+3xfloat64
+        latOff, lonOff, altOff = 12, 20, 28
+    default:
+        fmt.Printf("Unknown entry stride %d bytes — skipping batch\n", stride)
+        return
+    }
+
+    dataStart := unsafe.Pointer(
+        uintptr(unsafe.Pointer(list)) + headerSize,
+    )
+    for i := uint32(0); i < uint32(list.DwArraySize); i++ {
+        entry := unsafe.Pointer(uintptr(dataStart) + uintptr(i)*stride)
+
+        var ident [6]byte
+        copy(ident[:], (*[6]byte)(entry)[:])
+
+        lat := *(*float64)(unsafe.Pointer(uintptr(entry) + latOff))
+        lon := *(*float64)(unsafe.Pointer(uintptr(entry) + lonOff))
+        alt := *(*float64)(unsafe.Pointer(uintptr(entry) + altOff))
+
+        fmt.Printf("  %s  lat=%.4f lon=%.4f alt=%.1fm\n",
+            engine.BytesToString(ident[:]), lat, lon, alt)
+    }
+}
+```
+
+> **Note:** The `SIMCONNECT_DATA_FACILITY_AIRPORT` struct in `pkg/types` has alignment padding that differs from the SimConnect wire format. Never cast a multi-entry list buffer directly to this struct. Use runtime stride arithmetic as shown above. See the inline comment in `pkg/types/facility.go` for details.
+
+### Message Helpers for List Responses
+
+Use these typed accessors instead of casting manually:
+
+| Method | Returns | Message ID |
+|--------|---------|-----------|
+| `msg.AsAirportList()` | `*SIMCONNECT_RECV_AIRPORT_LIST` | `SIMCONNECT_RECV_ID_AIRPORT_LIST` |
+| `msg.AsVORList()` | `*SIMCONNECT_RECV_VOR_LIST` | `SIMCONNECT_RECV_ID_VOR_LIST` |
+| `msg.AsNDBList()` | `*SIMCONNECT_RECV_NDB_LIST` | `SIMCONNECT_RECV_ID_NDB_LIST` |
+| `msg.AsWaypointList()` | `*SIMCONNECT_RECV_WAYPOINT_LIST` | `SIMCONNECT_RECV_ID_WAYPOINT_LIST` |
+| `msg.AsFacilityList()` | `*SIMCONNECT_RECV_FACILITIES_LIST` | Any of the above |
+
+`AsFacilityList()` matches any of the four list message types and returns the base struct that contains the pagination fields (`DwRequestID`, `DwArraySize`, `DwEntryNumber`, `DwOutOf`).
+
+## Subscriptions
+
+Subscriptions keep you informed as facilities enter and leave the simulator's active radius, without polling.
+
+### SubscribeToFacilities
+
+Registers a subscription for a facility type. SimConnect sends batches as the user's aircraft moves and new facilities come into range.
+
+**Signature:**
+
+```go
+//go:build windows
+
+func (e *Engine) SubscribeToFacilities(listType types.SIMCONNECT_FACILITY_LIST_TYPE, requestID uint32) error
+```
+
+```go
+//go:build windows
+
+const AirportSubReqID = 5000
+
+client.SubscribeToFacilities(types.SIMCONNECT_FACILITY_LIST_AIRPORT, AirportSubReqID)
+```
+
+Responses arrive as `SIMCONNECT_RECV_ID_AIRPORT_LIST` messages. Handle them with `msg.AsAirportList()`.
+
+### SubscribeToFacilitiesEX1
+
+The extended variant uses two separate request IDs — one for facilities coming into range, one for facilities going out of range. This makes it straightforward to maintain a live set of nearby facilities.
+
+**Signature:**
+
+```go
+//go:build windows
+
+func (e *Engine) SubscribeToFacilitiesEX1(
+    listType            types.SIMCONNECT_FACILITY_LIST_TYPE,
+    newElemInRangeRequestID  uint32,
+    oldElemOutRangeRequestID uint32,
+) error
+```
+
+```go
+//go:build windows
+
+const (
+    VorInRangeReqID  = 5010
+    VorOutRangeReqID = 5011
+)
+
+client.SubscribeToFacilitiesEX1(
+    types.SIMCONNECT_FACILITY_LIST_TYPE_VOR,
+    VorInRangeReqID,
+    VorOutRangeReqID,
+)
+```
+
+In your dispatch loop, check `msg.DwRequestID` (inside the list struct) against each ID to determine whether the batch represents facilities entering or leaving range.
+
+### UnsubscribeToFacilitiesEX1
+
+Removes one or both sides of an EX1 subscription independently.
+
+**Signature:**
+
+```go
+//go:build windows
+
+func (e *Engine) UnsubscribeToFacilitiesEX1(
+    listType              types.SIMCONNECT_FACILITY_LIST_TYPE,
+    unsubscribeNewInRange bool,
+    unsubscribeOldOutRange bool,
+) error
+```
+
+```go
+//go:build windows
+
+// Stop receiving out-of-range notifications, keep in-range
+client.UnsubscribeToFacilitiesEX1(
+    types.SIMCONNECT_FACILITY_LIST_TYPE_VOR,
+    false, // keep newInRange
+    true,  // remove oldOutRange
+)
+```
+
+## Jetway Data
+
+`RequestJetwayData` retrieves jetway state for specific gate indexes at an airport.
+
+**Signature:**
+
+```go
+//go:build windows
+
+func (e *Engine) RequestJetwayData(airportICAO string, arrayCount uint32, indexes *int32) error
+```
+
+`indexes` is a pointer to the first element of an `int32` slice listing which jetway gate indexes to query. `arrayCount` is the number of indexes in that slice.
+
+```go
+//go:build windows
+
+// Query jetwavs at gate indexes 0, 1, and 2 of EGLL
+gates := []int32{0, 1, 2}
+client.RequestJetwayData("EGLL", uint32(len(gates)), &gates[0])
+```
+
+Jetway responses arrive as `SIMCONNECT_RECV_ID_FACILITY_DATA` messages with `Type` equal to `SIMCONNECT_FACILITY_DATA_JETWAY`. Use `msg.AsFacilityData()` and cast `Data` to your jetway struct, or use `NewJetwayFacilityDataset()` to set up the definition first.
+
+## Filters
+
+Filters narrow the fields returned within a facility definition. They are applied per-definition, not per-request.
+
+### AddFacilityDataDefinitionFilter
+
+Adds a filter to a facility data definition. Only facilities matching the filter condition are included in the response.
+
+**Signature:**
+
+```go
+//go:build windows
+
+func (e *Engine) AddFacilityDataDefinitionFilter(
+    definitionID  uint32,
+    filterPath    string,
+    filterData    unsafe.Pointer,
+    filterDataSize uint32,
+) error
+```
+
+The `filterPath` is a dot-separated path to the field being filtered (for example `"TYPE"`). `filterData` points to the value to match against; `filterDataSize` is its byte size.
+
+```go
+//go:build windows
+
+import "unsafe"
+
+// Filter parking spots to heavy gates only
+parkingType := uint32(10) // SIMCONNECT_FACILITY_TAXI_PARKING_TYPE_GATE_HEAVY
+client.AddFacilityDataDefinitionFilter(
+    ParkingDefID,
+    "TYPE",
+    unsafe.Pointer(&parkingType),
+    uint32(unsafe.Sizeof(parkingType)),
+)
+```
+
+### ClearAllFacilityDataDefinitionFilters
+
+Removes all filters from a definition, restoring unfiltered results.
+
+**Signature:**
+
+```go
+//go:build windows
+
+func (e *Engine) ClearAllFacilityDataDefinitionFilters(definitionID uint32) error
+```
+
+```go
+//go:build windows
+
+client.ClearAllFacilityDataDefinitionFilters(ParkingDefID)
+```
+
+## Message Helpers Reference
+
+The `engine.Message` struct exposes these facility-related cast methods:
+
+| Method | Return type | When to use |
+|--------|------------|-------------|
+| `AsFacilityData()` | `*SIMCONNECT_RECV_FACILITY_DATA` | Each record from `RequestFacilityData` or `RequestFacilityDataEX1` |
+| `AsFacilityDataEnd()` | `*SIMCONNECT_RECV_FACILITY_DATA_END` | Signals the end of a `RequestFacilityData` response sequence |
+| `AsFacilityList()` | `*SIMCONNECT_RECV_FACILITIES_LIST` | Base struct for any list message; contains pagination fields |
+| `AsAirportList()` | `*SIMCONNECT_RECV_AIRPORT_LIST` | Airport enumeration batches |
+| `AsVORList()` | `*SIMCONNECT_RECV_VOR_LIST` | VOR enumeration batches |
+| `AsNDBList()` | `*SIMCONNECT_RECV_NDB_LIST` | NDB enumeration batches |
+| `AsWaypointList()` | `*SIMCONNECT_RECV_WAYPOINT_LIST` | Waypoint enumeration batches |
+
+Each method returns `nil` if the message type does not match, so nil-checking is safe in a type-switch fallthrough path.
+
+### SIMCONNECT_RECV_FACILITY_DATA Fields
+
+```go
+//go:build windows
+
+fd := msg.AsFacilityData()
+// fd.UserRequestId       — matches the requestID you passed to RequestFacilityData
+// fd.UniqueRequestId     — internal SimConnect identifier for this record
+// fd.ParentUniqueRequestId — identifier of the parent record (for nested types)
+// fd.Type                — SIMCONNECT_FACILITY_DATA_TYPE (airport, runway, parking, etc.)
+// fd.IsListItem          — true when the record is part of a child list (e.g., a parking spot)
+// fd.ItemIndex           — zero-based index within the child list
+// fd.ListSize            — total items in the child list
+// fd.Data                — opaque DWORD; pass to engine.CastDataAs[YourStruct](&fd.Data)
+```
+
+The `Type` field maps to `SIMCONNECT_FACILITY_DATA_TYPE` constants in `pkg/types/facility.go`. The complete set includes `SIMCONNECT_FACILITY_DATA_AIRPORT`, `SIMCONNECT_FACILITY_DATA_RUNWAY`, `SIMCONNECT_FACILITY_DATA_TAXI_PARKING`, `SIMCONNECT_FACILITY_DATA_JETWAY`, `SIMCONNECT_FACILITY_DATA_VOR`, `SIMCONNECT_FACILITY_DATA_NDB`, `SIMCONNECT_FACILITY_DATA_WAYPOINT`, and others.
+
+## See Also
+
+- [Engine/Client Usage](usage-client.md) — Connection lifecycle, stream setup, and data casting
+- [Manager Usage](usage-manager.md) — Auto-reconnect wrapper with facility helper methods
+- [`examples/read-facility`](../examples/read-facility) — Single airport lookup
+- [`examples/airport-details`](../examples/airport-details) — Multi-definition airport inspection including parking and taxiways
+- [`examples/all-facilities`](../examples/all-facilities) — Full airport enumeration with stride arithmetic

--- a/docs/guide-input-events.md
+++ b/docs/guide-input-events.md
@@ -1,0 +1,344 @@
+---
+title: "Input Events"
+description: "Enumerate, read, write, and subscribe to MSFS 2024 Input Events via the SimConnect API."
+order: 9
+section: "client"
+---
+
+# Input Events
+
+> **MSFS 2024 only.** The Input Event API (`EnumerateInputEvents`, `GetInputEvent`, `SetInputEvent`, `SubscribeInputEvent`, `UnsubscribeInputEvent`) is not present in the MSFS 2020 SimConnect SDK. Calling these methods against an MSFS 2020 installation will return an error. The `As*` message helpers (`AsEnumerateInputEvents()`, `AsGetInputEvent()`, `AsSubscribeInputEvent()`) will always return `nil` when connected to MSFS 2020 because the simulator never sends the corresponding `DwID` values.
+
+> **See also:** [Engine/Client API Reference](usage-engine-api.md) for the full API surface, including the Input Event section with a compact example.
+
+## What Are Input Events?
+
+Input Events are hash-addressed simulator events that map to physical cockpit interactions. They represent things like button presses, switch states, and knob positions in aircraft panels. Unlike SimVars, which describe the state of the simulation world, Input Events are the raw input bindings — the same ones the simulator uses internally to trigger avionics logic.
+
+You discover available events at runtime by enumerating them. Each event has a human-readable name, a 32-bit descriptor hash, and a value type (numeric or string). Once you have the name or hash you need, you can read the current value, write a new value, or subscribe to receive a notification every time the value changes.
+
+Common use cases include:
+
+- Building hardware panel integrations that reflect cockpit switch state
+- Monitoring whether a specific button was pressed
+- Driving cockpit state from an external source without going through SimVar writes
+
+## Enumerate Available Events
+
+Call `EnumerateInputEvents` to request the full list of available input events. The simulator responds with one or more `SIMCONNECT_RECV_ID_ENUMERATE_INPUT_EVENTS` messages, each containing a batch of descriptors.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+
+    "github.com/mrlm-net/simconnect/pkg/engine"
+    "github.com/mrlm-net/simconnect/pkg/types"
+)
+
+const EnumReqID uint32 = 1000
+
+func main() {
+    client := engine.New("InputEventEnum")
+    if err := client.Connect(); err != nil {
+        panic(err)
+    }
+    defer client.Disconnect()
+
+    if err := client.EnumerateInputEvents(EnumReqID); err != nil {
+        panic(err)
+    }
+
+    for msg := range client.Stream() {
+        if types.SIMCONNECT_RECV_ID(msg.DwID) != types.SIMCONNECT_RECV_ID_ENUMERATE_INPUT_EVENTS {
+            continue
+        }
+        recv := msg.AsEnumerateInputEvents()
+        if recv == nil {
+            continue
+        }
+        // recv.DwArraySize tells you how many descriptors are in this batch.
+        // Access elements at recv.RgData[0] through recv.RgData[count-1].
+        count := int(recv.DwArraySize)
+        for i := 0; i < count; i++ {
+            desc := recv.RgData[i]
+            name := engine.BytesToString(desc.Name[:])
+            fmt.Printf("Event: %-64s  hash=0x%08X  type=%d\n", name, desc.Hash, desc.Type)
+        }
+        // DwEntryNumber and DwOutOf let you track batched delivery.
+        if recv.DwEntryNumber+1 >= recv.DwOutOf {
+            fmt.Println("Enumeration complete.")
+            break
+        }
+    }
+}
+```
+
+**Signature:** `EnumerateInputEvents(requestID uint32) error`
+
+`SIMCONNECT_INPUT_EVENT_DESCRIPTOR` fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `Name` | `[64]byte` | Human-readable event name, null-terminated. Use `engine.BytesToString(desc.Name[:])` to convert. |
+| `Hash` | `DWORD` (32-bit) | Descriptor hash for this event. Cast to `uint64` when calling `GetInputEvent`, `SetInputEvent*`, or `SubscribeInputEvent`. |
+| `Type` | `SIMCONNECT_DATATYPE` | Value type of the event (`SIMCONNECT_INPUT_EVENT_TYPE_DOUBLE` or `SIMCONNECT_INPUT_EVENT_TYPE_STRING`). |
+| `NodeNames` | `[1024]byte` | Null-separated list of associated node names. |
+
+> **Note:** The `Hash` field in `SIMCONNECT_INPUT_EVENT_DESCRIPTOR` is a 32-bit `DWORD`. The DLL API calls (`GetInputEvent`, `SetInputEventDouble`, `SetInputEventString`, `SubscribeInputEvent`, `UnsubscribeInputEvent`) all take a `uint64` hash parameter. Cast explicitly: `uint64(desc.Hash)`.
+
+## Get Event Value
+
+To read the current value of a known event, call `GetInputEvent` with a request ID and the event's 64-bit hash. The response arrives asynchronously as a `SIMCONNECT_RECV_ID_GET_INPUT_EVENT` message.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+
+    "github.com/mrlm-net/simconnect/pkg/engine"
+    "github.com/mrlm-net/simconnect/pkg/types"
+)
+
+const GetReqID uint32 = 1001
+
+func main() {
+    client := engine.New("InputEventGet")
+    if err := client.Connect(); err != nil {
+        panic(err)
+    }
+    defer client.Disconnect()
+
+    // hash is a uint64 obtained from enumeration or a known constant.
+    var hash uint64 = 0x00000001
+
+    if err := client.GetInputEvent(GetReqID, hash); err != nil {
+        panic(err)
+    }
+
+    for msg := range client.Stream() {
+        if types.SIMCONNECT_RECV_ID(msg.DwID) != types.SIMCONNECT_RECV_ID_GET_INPUT_EVENT {
+            continue
+        }
+        recv := msg.AsGetInputEvent()
+        if recv == nil || uint32(recv.RequestID) != GetReqID {
+            continue
+        }
+        if f, ok := engine.InputEventValueAsFloat64(recv); ok {
+            fmt.Printf("Value (float64): %f\n", f)
+        }
+        if s, ok := engine.InputEventValueAsString(recv); ok {
+            fmt.Printf("Value (string): %s\n", s)
+        }
+        break
+    }
+}
+```
+
+**Signature:** `GetInputEvent(requestID uint32, hash uint64) error`
+
+Value extraction helpers for `*types.SIMCONNECT_RECV_GET_INPUT_EVENT`:
+
+| Helper | Signature | Returns |
+|---|---|---|
+| `engine.InputEventValueAsFloat64` | `(recv *types.SIMCONNECT_RECV_GET_INPUT_EVENT) (float64, bool)` | Value and `true` when type is `DOUBLE`; `(0, false)` otherwise |
+| `engine.InputEventValueAsString` | `(recv *types.SIMCONNECT_RECV_GET_INPUT_EVENT) (string, bool)` | Value and `true` when type is `STRING`; `("", false)` otherwise |
+
+## Set Event Value
+
+To write a value to an input event, use `SetInputEventDouble` for numeric events or `SetInputEventString` for string-typed events. Both calls are fire-and-forget — there is no response message. Any HRESULT error is returned directly from the call.
+
+```go
+//go:build windows
+
+// Write a numeric value to a DOUBLE-typed event.
+err := client.SetInputEventDouble(hash, 1.0)
+if err != nil {
+    // HRESULT error returned directly — no response message.
+    panic(err)
+}
+
+// Write a string value to a STRING-typed event.
+// Strings longer than 259 bytes are silently truncated to preserve the null terminator.
+err = client.SetInputEventString(hash, "AUTOPILOT_ON")
+if err != nil {
+    panic(err)
+}
+```
+
+**Signatures:**
+
+- `SetInputEventDouble(hash uint64, value float64) error`
+- `SetInputEventString(hash uint64, value string) error`
+
+## Subscribe to Changes
+
+Subscribing to an input event causes the simulator to push a notification message every time the event value changes. Use this instead of polling `GetInputEvent` in a loop.
+
+```go
+//go:build windows
+
+err := client.SubscribeInputEvent(hash)
+```
+
+**Signature:** `SubscribeInputEvent(hash uint64) error`
+
+Change notifications arrive as `SIMCONNECT_RECV_ID_SUBSCRIBE_INPUT_EVENT` messages. Cast with `msg.AsSubscribeInputEvent()` and use the engine helpers to extract the hash and value:
+
+```go
+//go:build windows
+
+if recv := msg.AsSubscribeInputEvent(); recv != nil {
+    // Read the hash from the wire struct (stored as [8]byte due to alignment).
+    eventHash := engine.SubscribeInputEventHash(recv)
+
+    if f, ok := engine.SubscribeInputEventValueAsFloat64(recv); ok {
+        fmt.Printf("Event %d changed → %f\n", eventHash, f)
+    }
+    if s, ok := engine.SubscribeInputEventValueAsString(recv); ok {
+        fmt.Printf("Event %d changed → %s\n", eventHash, s)
+    }
+}
+```
+
+> **Note:** `SIMCONNECT_RECV_SUBSCRIBE_INPUT_EVENT.HashBytes` is stored as `[8]byte` at wire offset 12 rather than `uint64`. This avoids the 4-byte alignment padding Go would otherwise insert, which would shift the field to the wrong offset. Always use `engine.SubscribeInputEventHash(recv)` rather than reading `HashBytes` directly with `binary.LittleEndian.Uint64`.
+
+Value extraction helpers for `*types.SIMCONNECT_RECV_SUBSCRIBE_INPUT_EVENT`:
+
+| Helper | Signature | Returns |
+|---|---|---|
+| `engine.SubscribeInputEventHash` | `(recv *types.SIMCONNECT_RECV_SUBSCRIBE_INPUT_EVENT) uint64` | The 64-bit event hash |
+| `engine.SubscribeInputEventValueAsFloat64` | `(recv *types.SIMCONNECT_RECV_SUBSCRIBE_INPUT_EVENT) (float64, bool)` | Value and `true` when type is `DOUBLE` |
+| `engine.SubscribeInputEventValueAsString` | `(recv *types.SIMCONNECT_RECV_SUBSCRIBE_INPUT_EVENT) (string, bool)` | Value and `true` when type is `STRING` |
+
+## Unsubscribe
+
+Cancel a subscription by passing the same hash you used to subscribe:
+
+```go
+//go:build windows
+
+err := client.UnsubscribeInputEvent(hash)
+```
+
+**Signature:** `UnsubscribeInputEvent(hash uint64) error`
+
+Call this before disconnecting if you want to be explicit, or when you no longer need change notifications for a particular event.
+
+## Hash Note
+
+There are two hash representations in this API, and it is important not to conflate them:
+
+- **`SIMCONNECT_INPUT_EVENT_DESCRIPTOR.Hash`** — a `DWORD` (32-bit unsigned integer) returned in the enumeration response. Cast it to `uint64` when passing it to any DLL call: `uint64(desc.Hash)`.
+- **`SIMCONNECT_RECV_SUBSCRIBE_INPUT_EVENT.HashBytes`** — a `[8]byte` field at wire offset 12 in the subscribe notification struct. This is a full 64-bit hash stored as raw bytes to work around Go's alignment rules. Use `engine.SubscribeInputEventHash(recv)` to decode it.
+
+The two hashes are not necessarily the same value. The descriptor hash is a compact identifier used at enumeration time. The subscription notification carries the full 64-bit hash the simulator uses internally. Use the value from the subscribe notification if you need to correlate events back to subscriptions in your own bookkeeping.
+
+## Complete Example
+
+This example enumerates all available input events, subscribes to the first one found, then prints every change notification until interrupted.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+    "os"
+    "os/signal"
+
+    "github.com/mrlm-net/simconnect/pkg/engine"
+    "github.com/mrlm-net/simconnect/pkg/types"
+)
+
+const EnumReqID uint32 = 2000
+
+func main() {
+    client := engine.New("InputEventDemo")
+    if err := client.Connect(); err != nil {
+        panic(err)
+    }
+    defer client.Disconnect()
+
+    // Step 1: request the full list of available input events.
+    if err := client.EnumerateInputEvents(EnumReqID); err != nil {
+        panic(err)
+    }
+
+    sigChan := make(chan os.Signal, 1)
+    signal.Notify(sigChan, os.Interrupt)
+
+    var subscribedHash uint64
+
+    for {
+        select {
+        case <-sigChan:
+            // Clean up subscription before exit.
+            if subscribedHash != 0 {
+                client.UnsubscribeInputEvent(subscribedHash)
+            }
+            fmt.Println("Shutting down.")
+            return
+
+        case msg, ok := <-client.Stream():
+            if !ok {
+                return
+            }
+
+            switch types.SIMCONNECT_RECV_ID(msg.DwID) {
+
+            case types.SIMCONNECT_RECV_ID_ENUMERATE_INPUT_EVENTS:
+                recv := msg.AsEnumerateInputEvents()
+                if recv == nil {
+                    continue
+                }
+                // Print the first descriptor in this batch.
+                name := engine.BytesToString(recv.RgData[0].Name[:])
+                fmt.Printf("Found event: %s\n", name)
+
+                // Subscribe to the first event we see.
+                if subscribedHash == 0 {
+                    subscribedHash = uint64(recv.RgData[0].Hash)
+                    if err := client.SubscribeInputEvent(subscribedHash); err != nil {
+                        fmt.Printf("SubscribeInputEvent failed: %v\n", err)
+                    } else {
+                        fmt.Printf("Subscribed to hash 0x%016X (%s)\n", subscribedHash, name)
+                    }
+                }
+
+            case types.SIMCONNECT_RECV_ID_SUBSCRIBE_INPUT_EVENT:
+                recv := msg.AsSubscribeInputEvent()
+                if recv == nil {
+                    continue
+                }
+                hash := engine.SubscribeInputEventHash(recv)
+                if f, ok := engine.SubscribeInputEventValueAsFloat64(recv); ok {
+                    fmt.Printf("Event 0x%016X changed → %f\n", hash, f)
+                }
+                if s, ok := engine.SubscribeInputEventValueAsString(recv); ok {
+                    fmt.Printf("Event 0x%016X changed → %s\n", hash, s)
+                }
+
+            case types.SIMCONNECT_RECV_ID_EXCEPTION:
+                recv := msg.AsException()
+                if recv != nil {
+                    fmt.Printf("SimConnect exception: %d\n", recv.DwException)
+                }
+            }
+        }
+    }
+}
+```
+
+## See Also
+
+- [Engine/Client API Reference](usage-engine-api.md) — Full Input Event API section with the complete method reference table
+- [Engine/Client Usage](usage-client.md) — General dispatch loop patterns and message handling
+- [Client Configuration](config-client.md) — Connection options

--- a/docs/guide-traffic.md
+++ b/docs/guide-traffic.md
@@ -1,0 +1,432 @@
+---
+title: "AI Traffic"
+description: "Inject and manage AI aircraft using the Engine client AI object API."
+order: 7
+section: "client"
+---
+
+# AI Traffic
+
+This guide covers AI aircraft injection using the Engine client's `AICreate*` methods — thin, typed wrappers over the raw SimConnect DLL. Every call maps directly to a single SimConnect API function with no extra abstraction.
+
+> **See also:** If you want a higher-level fleet management abstraction with pooling, scheduling, and state tracking, see [traffic-guide.md](traffic-guide.md).
+
+## Aircraft Kinds
+
+SimConnect exposes four creation APIs, each suited to a different role:
+
+| Kind | Method | When to use |
+|------|--------|-------------|
+| **Parked ATC** | `AICreateParkedATCAircraft` | Static ground traffic at a known airport. SimConnect places the aircraft at a free parking spot. No position required. |
+| **Enroute ATC** | `AICreateEnrouteATCAircraft` | Aircraft mid-flight following an MSFS `.pln` flight plan. SimConnect positions the aircraft along the route at the given progress fraction. |
+| **Non-ATC** | `AICreateNonATCAircraft` | Aircraft at an explicit world position. Required when you need precise gate/apron placement or airborne injection outside the ATC system. |
+| **Simulated Object** | `AICreateSimulatedObject` | Non-aircraft objects: ground vehicles, boats, or any container title that is not an aircraft. |
+
+All four return an object ID asynchronously via `SIMCONNECT_RECV_ID_ASSIGNED_OBJECT_ID`.
+
+## The Create-Acknowledge Pattern
+
+Every `AICreate*` call is fire-and-forget from the caller's perspective. You supply a `requestID` that you chose; SimConnect responds with `SIMCONNECT_RECV_ID_ASSIGNED_OBJECT_ID` carrying both your `requestID` and the live `objectID`. Store that `objectID` — it is what you need for every subsequent operation on the object.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+
+    "github.com/mrlm-net/simconnect/pkg/engine"
+    "github.com/mrlm-net/simconnect/pkg/types"
+)
+
+const reqCreate uint32 = 1000
+
+// Submit the create call — objectID is not yet known.
+client.AICreateParkedATCAircraft("FSLTL A320 Air France SL", "N12345", "EGLL", reqCreate)
+
+// In the message loop, wait for the acknowledgement.
+for msg := range client.Stream() {
+    switch types.SIMCONNECT_RECV_ID(msg.DwID) {
+
+    case types.SIMCONNECT_RECV_ID_ASSIGNED_OBJECT_ID:
+        assigned := msg.AsAssignedObjectID()
+        if uint32(assigned.DwRequestID) == reqCreate {
+            objectID := uint32(assigned.DwObjectID)
+            fmt.Printf("Aircraft spawned: objectID=%d\n", objectID)
+            // objectID is now valid for AIRemoveObject, AIReleaseControl, etc.
+        }
+    }
+}
+```
+
+`AsAssignedObjectID()` returns `nil` when the message is not of that type, so the switch-case guard is sufficient — no additional nil-check is needed inside the `case` block.
+
+## Parked ATC Aircraft
+
+`AICreateParkedATCAircraft` places an aircraft at a free parking spot at the given airport. SimConnect selects the spot; you do not control the exact gate or ramp position.
+
+**Signature:**
+
+```go
+func (e *Engine) AICreateParkedATCAircraft(
+    szContainerTitle string, // Aircraft model container title (exact match required)
+    szTailNumber     string, // Tail / registration number shown in cockpit and ATC
+    szAirportID      string, // ICAO airport code
+    RequestID        uint32, // Your request ID — returned in ASSIGNED_OBJECT_ID
+) error
+```
+
+**Example — spawn a parked aircraft at Prague:**
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "context"
+    "fmt"
+
+    simconnect "github.com/mrlm-net/simconnect"
+    "github.com/mrlm-net/simconnect/pkg/engine"
+    "github.com/mrlm-net/simconnect/pkg/types"
+)
+
+const (
+    reqPark uint32 = 1000
+)
+
+func main() {
+    ctx := context.Background()
+    client := simconnect.NewClient("ParkedTraffic", engine.WithContext(ctx))
+    if err := client.Connect(); err != nil {
+        panic(err)
+    }
+    defer client.Disconnect()
+
+    // Queue the create call — SimConnect places the aircraft at a free spot.
+    client.AICreateParkedATCAircraft(
+        "FSLTL A320 Air France SL", // container title
+        "AFR123",                   // tail number
+        "LKPR",                     // ICAO
+        reqPark,
+    )
+
+    for msg := range client.Stream() {
+        switch types.SIMCONNECT_RECV_ID(msg.DwID) {
+
+        case types.SIMCONNECT_RECV_ID_ASSIGNED_OBJECT_ID:
+            a := msg.AsAssignedObjectID()
+            if uint32(a.DwRequestID) == reqPark {
+                fmt.Printf("Parked: objectID=%d\n", uint32(a.DwObjectID))
+            }
+
+        case types.SIMCONNECT_RECV_ID_EXCEPTION:
+            ex := msg.AsException()
+            fmt.Printf("SimConnect exception %d at index %d\n",
+                ex.DwException, ex.DwIndex)
+        }
+    }
+}
+```
+
+> **Note:** The container title must exactly match a model installed in the simulator. The `EnumerateSimObjectsAndLiveries` API, covered below, lets you discover valid titles at runtime.
+
+## Enroute ATC Aircraft
+
+`AICreateEnrouteATCAircraft` injects an aircraft into the ATC system mid-flight, following an MSFS `.pln` flight plan. SimConnect positions the aircraft at the given fractional position along the route.
+
+**Signature:**
+
+```go
+func (e *Engine) AICreateEnrouteATCAircraft(
+    szContainerTitle  string,  // Aircraft model container title
+    szTailNumber      string,  // Tail / registration number
+    iFlightNumber     uint32,  // ATC flight number (numeric part)
+    szFlightPlanPath  string,  // Absolute path to an MSFS .pln file
+    dFlightPlanPosition float64, // Route progress: 0.0 = start, 1.0 = destination
+    bTouchAndGo      bool,    // Whether the aircraft performs touch-and-go landings
+    RequestID        uint32,  // Your request ID
+) error
+```
+
+**Example — inject an aircraft at the beginning of a plan:**
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+    "path/filepath"
+
+    simconnect "github.com/mrlm-net/simconnect"
+    "github.com/mrlm-net/simconnect/pkg/engine"
+    "github.com/mrlm-net/simconnect/pkg/types"
+)
+
+const reqEnroute uint32 = 1001
+
+func spawnEnroute(client engine.Client, planDir string) {
+    client.AICreateEnrouteATCAircraft(
+        "FSLTL A320 Air France SL",
+        "AFR456",
+        456,
+        filepath.Join(planDir, "LKPREDDN_MFS_NoProc.pln"),
+        0.0,   // inject at the start of the plan
+        false, // not touch-and-go
+        reqEnroute,
+    )
+}
+
+func handleMessages(client engine.Client) {
+    for msg := range client.Stream() {
+        switch types.SIMCONNECT_RECV_ID(msg.DwID) {
+
+        case types.SIMCONNECT_RECV_ID_ASSIGNED_OBJECT_ID:
+            a := msg.AsAssignedObjectID()
+            if uint32(a.DwRequestID) == reqEnroute {
+                fmt.Printf("Enroute aircraft: objectID=%d\n", uint32(a.DwObjectID))
+            }
+        }
+    }
+}
+
+func main() {
+    client := simconnect.NewClient("EnrouteTraffic")
+    if err := client.Connect(); err != nil {
+        panic(err)
+    }
+    defer client.Disconnect()
+
+    spawnEnroute(client, `C:\MSFS-TEST-PLANS`)
+    handleMessages(client)
+}
+```
+
+> **Note:** The flight plan path must be an absolute Windows path to an MSFS-compatible `.pln` file. Relative paths are not supported by the SimConnect API.
+
+## Non-ATC Aircraft at an Explicit Position
+
+`AICreateNonATCAircraft` gives you full control over initial position, heading, altitude, and airspeed. Use this when you need to place an aircraft at a specific gate, apron stand, or airborne location that is not managed by ATC.
+
+**Signature:**
+
+```go
+func (e *Engine) AICreateNonATCAircraft(
+    szContainerTitle string,
+    szTailNumber     string,
+    initPos          types.SIMCONNECT_DATA_INITPOSITION,
+    RequestID        uint32,
+) error
+```
+
+**`SIMCONNECT_DATA_INITPOSITION` fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Latitude` | `float64` | Decimal degrees, positive = north |
+| `Longitude` | `float64` | Decimal degrees, positive = east |
+| `Altitude` | `float64` | Feet MSL (not meters) |
+| `Pitch` | `float64` | Degrees, positive = nose up |
+| `Bank` | `float64` | Degrees, positive = right wing down |
+| `Heading` | `float64` | True degrees (0–360) |
+| `OnGround` | `DWORD` | 1 = on ground, 0 = airborne |
+| `Airspeed` | `DWORD` | Knots; use `SIMCONNECT_DATA_INITPOSITION_AIRSPEED_CRUISE` (-1) for cruise speed |
+
+**Example — spawn an aircraft at a specific gate:**
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+
+    simconnect "github.com/mrlm-net/simconnect"
+    "github.com/mrlm-net/simconnect/pkg/engine"
+    "github.com/mrlm-net/simconnect/pkg/types"
+)
+
+const reqNonATC uint32 = 1002
+
+func main() {
+    client := simconnect.NewClient("NonATCTraffic")
+    if err := client.Connect(); err != nil {
+        panic(err)
+    }
+    defer client.Disconnect()
+
+    // Precise gate coordinates obtained from facility data.
+    client.AICreateNonATCAircraft(
+        "FSLTL A320 Air France SL",
+        "N99001",
+        types.SIMCONNECT_DATA_INITPOSITION{
+            Latitude:  50.1006, // gate lat (decimal degrees)
+            Longitude: 14.2601, // gate lon
+            Altitude:  1247,    // feet MSL (Prague elevation)
+            Heading:   245,     // facing apron
+            OnGround:  1,       // parked
+            Airspeed:  0,
+        },
+        reqNonATC,
+    )
+
+    for msg := range client.Stream() {
+        if types.SIMCONNECT_RECV_ID(msg.DwID) == types.SIMCONNECT_RECV_ID_ASSIGNED_OBJECT_ID {
+            a := msg.AsAssignedObjectID()
+            if uint32(a.DwRequestID) == reqNonATC {
+                fmt.Printf("Non-ATC aircraft: objectID=%d\n", uint32(a.DwObjectID))
+            }
+        }
+    }
+}
+```
+
+## EX1 Variants — Livery Selection
+
+The `EX1` variants of all three aircraft creation methods add a `szLivery` parameter that lets you specify an exact livery by name rather than accepting the model's default.
+
+```go
+func (e *Engine) AICreateParkedATCAircraftEX1(
+    szContainerTitle string,
+    szLivery         string, // Exact livery name; empty string = default livery
+    szTailNumber     string,
+    szAirportID      string,
+    RequestID        uint32,
+) error
+
+func (e *Engine) AICreateEnrouteATCAircraftEX1(
+    szContainerTitle    string,
+    szLivery            string,
+    szTailNumber        string,
+    iFlightNumber       uint32,
+    szFlightPlanPath    string,
+    dFlightPlanPosition float64,
+    bTouchAndGo        bool,
+    RequestID          uint32,
+) error
+
+func (e *Engine) AICreateNonATCAircraftEX1(
+    szContainerTitle string,
+    szLivery         string,
+    szTailNumber     string,
+    initPos          types.SIMCONNECT_DATA_INITPOSITION,
+    RequestID        uint32,
+) error
+```
+
+**Example — parked aircraft with an explicit livery:**
+
+```go
+//go:build windows
+
+client.AICreateParkedATCAircraftEX1(
+    "Boeing 787-10 Asobo",
+    "House",   // livery name as returned by EnumerateSimObjectsAndLiveries
+    "BOE787",
+    "KSEA",
+    1003,
+)
+```
+
+Pass an empty string (`""`) for `szLivery` to use the model default. The `EX1` variants are MSFS 2024 additions; on MSFS 2020 they are available from SimConnect SDK version 11 onwards.
+
+## Object Management
+
+### Removing an Object
+
+`AIRemoveObject` destroys an AI object and removes it from the simulation. The `requestID` is for your own correlation; no meaningful acknowledgement is returned for removal.
+
+```go
+//go:build windows
+
+if err := client.AIRemoveObject(objectID, reqRemove); err != nil {
+    // handle DLL call failure
+}
+```
+
+Call this during shutdown to clean up all spawned objects before disconnecting.
+
+### Releasing Control
+
+`AIReleaseControl` transfers ownership of an AI object from your add-on back to the simulator's AI system. After release, the simulator drives the object autonomously. You can still send waypoints via `SetDataOnSimObject` before releasing if you want to set an initial route.
+
+```go
+//go:build windows
+
+// Release AI control — simulator takes over.
+client.AIReleaseControl(objectID, reqRelease)
+```
+
+This is the correct sequence when you want the aircraft to taxi and depart autonomously after providing a waypoint set.
+
+### Assigning a Flight Plan
+
+`AISetAircraftFlightPlan` assigns or replaces the flight plan on an existing AI aircraft. The object must already exist (use the `objectID` from `ASSIGNED_OBJECT_ID`).
+
+```go
+//go:build windows
+
+client.AISetAircraftFlightPlan(
+    objectID,
+    `C:\MSFS-TEST-PLANS\LKPREDDN_MFS_NoProc.pln`,
+    reqFlightPlan,
+)
+```
+
+> **Note:** `AISetAircraftFlightPlan` does not return an `ASSIGNED_OBJECT_ID`. The `requestID` parameter is present for symmetry with the rest of the AI API but SimConnect does not dispatch a response message for this call.
+
+## Model Discovery
+
+Before spawning aircraft you need valid container titles and livery names. `EnumerateSimObjectsAndLiveries` requests the full list of installed models for a given object type.
+
+**Requesting the enumeration:**
+
+```go
+//go:build windows
+
+const reqEnum uint32 = 9000
+
+client.EnumerateSimObjectsAndLiveries(reqEnum, types.SIMCONNECT_SIMOBJECT_TYPE_AIRCRAFT)
+```
+
+**Receiving the results:**
+
+SimConnect returns one or more `SIMCONNECT_RECV_ID_ENUMERATE_SIMOBJECT_AND_LIVERY_LIST` messages. Each contains an array of `SIMCONNECT_ENUMERATE_SIMOBJECT_LIVERY` entries.
+
+```go
+//go:build windows
+
+case types.SIMCONNECT_RECV_ID_ENUMERATE_SIMOBJECT_AND_LIVERY_LIST:
+    list := msg.AsSimObjectAndLiveryEnumeration()
+    // list is *types.SIMCONNECT_RECV_ENUMERATE_SIMOBJECT_AND_LIVERY_LIST
+    for _, entry := range list.RgData {
+        title := engine.BytesToString(entry.AircraftTitle[:])
+        livery := engine.BytesToString(entry.LiveryName[:])
+        fmt.Printf("Title: %q  Livery: %q\n", title, livery)
+    }
+```
+
+`AsSimObjectAndLiveryEnumeration()` returns `nil` when the message is not of that type. The `RgData` slice is populated from the wire data and contains all entries in the current batch. SimConnect may send multiple messages for large model sets; collect them all before using the results.
+
+**Object type constants** for `EnumerateSimObjectsAndLiveries`:
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `SIMCONNECT_SIMOBJECT_TYPE_ALL` | 1 | All installed objects |
+| `SIMCONNECT_SIMOBJECT_TYPE_AIRCRAFT` | 2 | Fixed-wing aircraft only |
+| `SIMCONNECT_SIMOBJECT_TYPE_HELICOPTER` | 3 | Helicopters only |
+| `SIMCONNECT_SIMOBJECT_TYPE_BOAT` | 4 | Boats and watercraft |
+| `SIMCONNECT_SIMOBJECT_TYPE_GROUND` | 5 | Ground vehicles |
+
+## See Also
+
+- [Engine/Client Usage](usage-client.md) — Connection lifecycle, data definitions, message handling
+- [Client Configuration](config-client.md) — Configuration options for the Engine client
+- [traffic-guide.md](traffic-guide.md) — Higher-level `pkg/traffic.Fleet` abstraction
+- [examples/ai-traffic](../examples/ai-traffic) — Parked and enroute aircraft injection example
+- [examples/manage-traffic](../examples/manage-traffic) — Full departure sequence with facility data, waypoints, and cleanup

--- a/docs/guide-traffic.md
+++ b/docs/guide-traffic.md
@@ -9,7 +9,7 @@ section: "client"
 
 This guide covers AI aircraft injection using the Engine client's `AICreate*` methods — thin, typed wrappers over the raw SimConnect DLL. Every call maps directly to a single SimConnect API function with no extra abstraction.
 
-> **See also:** If you want a higher-level fleet management abstraction with pooling, scheduling, and state tracking, see [traffic-guide.md](traffic-guide.md).
+> **Scope:** This guide covers the raw Engine-layer `AICreate*` / `AIRemove*` / `AIRelease*` API. Manager-layer wrappers (`TrafficParked`, `TrafficEnroute`, `TrafficNonATC`, fleet tracking) and the `pkg/traffic.Fleet` abstraction are out of scope — see [traffic-guide.md](traffic-guide.md) for those.
 
 ## Aircraft Kinds
 

--- a/docs/usage-client.md
+++ b/docs/usage-client.md
@@ -1,7 +1,7 @@
 ---
 title: "Engine/Client Usage"
 description: "Complete API reference for direct simulator communication."
-order: 2
+order: 3
 section: "client"
 ---
 

--- a/docs/usage-datasets.md
+++ b/docs/usage-datasets.md
@@ -2,6 +2,7 @@
 title: "Using Datasets"
 description: "Pre-built dataset constructors for aircraft, environment, simulator, objects, and traffic data."
 order: 4
+section: "client"
 ---
 
 # Using Datasets

--- a/docs/usage-engine-api.md
+++ b/docs/usage-engine-api.md
@@ -1,0 +1,614 @@
+---
+title: "Engine API Reference"
+description: "Extended Engine client API: Client Data Areas, Input Events, and object enumeration."
+order: 5
+section: "client"
+---
+
+# Engine API Reference
+
+This document covers Engine client APIs added after the core reference was written. It is a companion to [Engine/Client Usage](usage-client.md), which covers connection lifecycle, data definitions, sim object requests, events, AI traffic, and facilities. Read that document first before using this one.
+
+The APIs documented here are:
+
+- **Client Data Area** — named shared memory regions for inter-add-on communication
+- **Input Event API** — read and write MSFS 2024 input events by hash (MSFS 2024 only)
+- **SimObject and Livery Enumeration** — list available aircraft models and their liveries
+
+---
+
+## Client Data Area API
+
+Client data areas are named shared memory regions that SimConnect clients use to exchange arbitrary binary data with each other. One add-on creates and owns the area; any other connected client can subscribe to updates. This is the standard SimConnect mechanism for inter-add-on communication.
+
+> **See also:** [Client Data Areas](client-data-area.md) for a full conceptual guide, field-by-field parameter tables, types reference, and a complete annotated example. This section summarises the API surface and provides a self-contained writer + reader example.
+
+### Setup workflow
+
+A client data area is set up in four steps:
+
+1. **Map name to ID** — both writer and reader call `MapClientDataNameToID` with the same string name.
+2. **Create the area** — the writer calls `CreateClientData` to register the area size and access flags. Readers skip this step.
+3. **Define fields** — both sides call `AddToClientDataDefinition` to describe the data layout.
+4. **Exchange data** — the writer calls `SetClientData` to write; the reader calls `RequestClientData` to subscribe.
+
+### MapClientDataNameToID
+
+Associates a human-readable name with a numeric client data ID. The name must match on both sides.
+
+```go
+err := client.MapClientDataNameToID("com.myaddon.channel", clientDataID)
+```
+
+**Signature:** `MapClientDataNameToID(clientDataName string, clientDataID uint32) error`
+
+### CreateClientData
+
+Registers the area with SimConnect. Call only from the owning (writer) client.
+
+```go
+err := client.CreateClientData(
+    clientDataID,
+    16,                                                   // size in bytes, max 8192
+    types.SIMCONNECT_CREATE_CLIENT_DATA_FLAG_DEFAULT,
+)
+```
+
+**Signature:** `CreateClientData(clientDataID uint32, dwSize uint32, flags types.SIMCONNECT_CREATE_CLIENT_DATA_FLAG) error`
+
+| Flag constant | Value | Meaning |
+|---|---|---|
+| `SIMCONNECT_CREATE_CLIENT_DATA_FLAG_DEFAULT` | `0` | Any client can write |
+| `SIMCONNECT_CREATE_CLIENT_DATA_FLAG_READ_ONLY` | `1` | Only the creator can write |
+
+The maximum area size is **8192 bytes**. SimConnect returns an HRESULT error for any value outside the range 1–8192.
+
+### AddToClientDataDefinition
+
+Adds a data field to a definition. Call multiple times to build composite layouts. Both the writer and the reader call this with the same `defineID` and offsets.
+
+```go
+err := client.AddToClientDataDefinition(
+    defineID,
+    0,                                               // byte offset within the area
+    uint32(types.SIMCONNECT_CLIENTDATATYPE_FLOAT64), // 8-byte float64
+    0,                                               // epsilon: 0 = notify on any change
+    0,                                               // datum ID: 0 for default mode
+)
+```
+
+**Signature:** `AddToClientDataDefinition(defineID uint32, dwOffset uint32, dwSizeOrType uint32, epsilon float32, datumID uint32) error`
+
+The `dwSizeOrType` parameter accepts either a raw byte count or one of the `SIMCONNECT_CLIENTDATATYPE_*` typed constants. The constants occupy the `0xFFFFFFFA`–`0xFFFFFFFF` range; SimConnect distinguishes them from byte counts. Always cast the constant to `uint32`.
+
+| Constant | Go type |
+|---|---|
+| `SIMCONNECT_CLIENTDATATYPE_INT8` | `int8` |
+| `SIMCONNECT_CLIENTDATATYPE_INT16` | `int16` |
+| `SIMCONNECT_CLIENTDATATYPE_INT32` | `int32` |
+| `SIMCONNECT_CLIENTDATATYPE_INT64` | `int64` |
+| `SIMCONNECT_CLIENTDATATYPE_FLOAT32` | `float32` |
+| `SIMCONNECT_CLIENTDATATYPE_FLOAT64` | `float64` |
+
+### RequestClientData
+
+Subscribes to updates. Use this on the reader side.
+
+```go
+err := client.RequestClientData(
+    clientDataID,
+    requestID,
+    defineID,
+    types.SIMCONNECT_CLIENT_DATA_PERIOD_ON_SET,
+    types.SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_DEFAULT,
+    0, 0, 0, // origin, interval, limit — 0 for defaults
+)
+```
+
+**Signature:** `RequestClientData(clientDataID uint32, requestID uint32, defineID uint32, period types.SIMCONNECT_CLIENT_DATA_PERIOD, flags types.SIMCONNECT_CLIENT_DATA_REQUEST_FLAG, origin uint32, interval uint32, limit uint32) error`
+
+Incoming data arrives as `SIMCONNECT_RECV_ID_CLIENT_DATA`. Cast with `msg.AsClientData()` and read the payload with `engine.CastDataAs`.
+
+### SetClientData
+
+Writes data to the area. Use this on the writer side.
+
+```go
+value := MyStruct{Field1: 15.5, Field2: 1013.25}
+err := client.SetClientData(
+    clientDataID,
+    defineID,
+    0,                            // flags — always 0; SimConnect defines no enum for this
+    0,                            // dwReserved — must be 0
+    uint32(unsafe.Sizeof(value)),
+    unsafe.Pointer(&value),
+)
+```
+
+**Signature:** `SetClientData(clientDataID uint32, defineID uint32, flags uint32, dwReserved uint32, cbUnitSize uint32, data unsafe.Pointer) error`
+
+> **Note:** The `flags` parameter is a plain `uint32`. SimConnect does not define a typed enum for it. Always pass `0`. The `dwReserved` parameter must also always be `0`.
+
+### Complete example
+
+The example below shows both sides of a shared data channel. The writer creates and populates a 16-byte area; the reader subscribes and prints values when they change.
+
+```go
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"unsafe"
+
+	"github.com/mrlm-net/simconnect/pkg/engine"
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+// SharedData is the layout both sides agree on.
+// 16 bytes total: two float64 fields at explicit offsets 0 and 8.
+type SharedData struct {
+	TemperatureC float64 // offset 0
+	PressureHPa  float64 // offset 8
+}
+
+const (
+	AreaID  uint32 = 1000
+	DefID   uint32 = 1001
+	ReqID   uint32 = 1002
+)
+
+// writerSetup creates and writes the area.
+// Call this from the add-on that owns the data.
+func writerSetup(client *engine.Engine) {
+	client.MapClientDataNameToID("com.example.weather", AreaID)
+	client.CreateClientData(AreaID, uint32(unsafe.Sizeof(SharedData{})),
+		types.SIMCONNECT_CREATE_CLIENT_DATA_FLAG_DEFAULT)
+
+	client.AddToClientDataDefinition(DefID, 0,
+		uint32(types.SIMCONNECT_CLIENTDATATYPE_FLOAT64), 0, 0)
+	client.AddToClientDataDefinition(DefID, 8,
+		uint32(types.SIMCONNECT_CLIENTDATATYPE_FLOAT64), 0, 0)
+
+	data := SharedData{TemperatureC: 15.5, PressureHPa: 1013.25}
+	client.SetClientData(AreaID, DefID, 0, 0,
+		uint32(unsafe.Sizeof(data)), unsafe.Pointer(&data))
+}
+
+// readerSetup subscribes to the area.
+// Call this from the add-on that reads the data.
+func readerSetup(client *engine.Engine) {
+	client.MapClientDataNameToID("com.example.weather", AreaID)
+
+	client.AddToClientDataDefinition(DefID, 0,
+		uint32(types.SIMCONNECT_CLIENTDATATYPE_FLOAT64), 0, 0)
+	client.AddToClientDataDefinition(DefID, 8,
+		uint32(types.SIMCONNECT_CLIENTDATATYPE_FLOAT64), 0, 0)
+
+	client.RequestClientData(
+		AreaID, ReqID, DefID,
+		types.SIMCONNECT_CLIENT_DATA_PERIOD_ON_SET,
+		types.SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_DEFAULT,
+		0, 0, 0,
+	)
+}
+
+func main() {
+	client := engine.New("WeatherReader")
+	if err := client.Connect(); err != nil {
+		panic(err)
+	}
+	defer client.Disconnect()
+
+	readerSetup(client)
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+
+	for {
+		select {
+		case <-sigChan:
+			return
+		case msg, ok := <-client.Stream():
+			if !ok {
+				return
+			}
+			switch types.SIMCONNECT_RECV_ID(msg.DwID) {
+			case types.SIMCONNECT_RECV_ID_CLIENT_DATA:
+				cd := msg.AsClientData()
+				if cd == nil || cd.DwRequestID != ReqID {
+					continue
+				}
+				data := engine.CastDataAs[SharedData](&cd.DwData)
+				fmt.Printf("Temperature: %.1f°C  Pressure: %.1f hPa\n",
+					data.TemperatureC, data.PressureHPa)
+			case types.SIMCONNECT_RECV_ID_EXCEPTION:
+				if ex := msg.AsException(); ex != nil {
+					fmt.Printf("SimConnect exception: %d\n", ex.DwException)
+				}
+			}
+		}
+	}
+}
+```
+
+---
+
+## Input Event API (MSFS 2024 only)
+
+> **MSFS 2024 exclusive.** The Input Event API requires Microsoft Flight Simulator 2024. All functions in this section will return HRESULT errors or produce undefined behaviour when called against MSFS 2020.
+
+Input events are named simulator actions identified by a 64-bit hash. They replace the legacy key event model for cockpit and aircraft interactions in MSFS 2024. You query available events by name, then read or write their values using the hash.
+
+Input events carry one of two value types, identified by `SIMCONNECT_INPUT_EVENT_TYPE`:
+
+| Constant | Meaning |
+|---|---|
+| `SIMCONNECT_INPUT_EVENT_TYPE_DOUBLE` | Numeric value; read and written as `float64` |
+| `SIMCONNECT_INPUT_EVENT_TYPE_STRING` | Text value; up to 259 bytes, null-terminated |
+
+### EnumerateInputEvents
+
+Requests a list of all available input events. Responses arrive as one or more `SIMCONNECT_RECV_ID_ENUMERATE_INPUT_EVENTS` messages; cast with `msg.AsEnumerateInputEvents()`.
+
+```go
+err := client.EnumerateInputEvents(requestID)
+```
+
+**Signature:** `EnumerateInputEvents(requestID uint32) error`
+
+Each response message contains a `RgData` array of `SIMCONNECT_INPUT_EVENT_DESCRIPTOR` elements:
+
+```go
+if recv := msg.AsEnumerateInputEvents(); recv != nil {
+    // DwArraySize tells you how many descriptors are in this batch
+    count := recv.DwArraySize
+    _ = count
+    // Access descriptors at &recv.RgData[0] through &recv.RgData[count-1]
+    name := engine.BytesToString(recv.RgData[0].Name[:])
+    fmt.Println("Event:", name)
+}
+```
+
+`SIMCONNECT_INPUT_EVENT_DESCRIPTOR` fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `Name` | `[64]byte` | Human-readable event name, null-terminated |
+| `Hash` | `DWORD` | 32-bit hash (use `GetInputEvent`/`SetInputEvent` with the full `uint64` hash from subscription) |
+| `Type` | `SIMCONNECT_DATATYPE` | Data type of the event value |
+| `NodeNames` | `[1024]byte` | Associated node names, null-separated |
+
+### GetInputEvent
+
+Requests the current value of a single input event identified by its 64-bit hash. The response arrives as `SIMCONNECT_RECV_ID_GET_INPUT_EVENT`; cast with `msg.AsGetInputEvent()`.
+
+```go
+err := client.GetInputEvent(requestID, hash)
+```
+
+**Signature:** `GetInputEvent(requestID uint32, hash uint64) error`
+
+Read the response value using the engine helpers:
+
+```go
+if recv := msg.AsGetInputEvent(); recv != nil && recv.RequestID == requestID {
+    if f, ok := engine.InputEventValueAsFloat64(recv); ok {
+        fmt.Printf("Value: %f\n", f)
+    }
+    if s, ok := engine.InputEventValueAsString(recv); ok {
+        fmt.Printf("Value: %s\n", s)
+    }
+}
+```
+
+| Helper | Signature | Returns |
+|---|---|---|
+| `InputEventValueAsFloat64` | `(recv *types.SIMCONNECT_RECV_GET_INPUT_EVENT) (float64, bool)` | Value and `true` when type is `DOUBLE`; `(0, false)` otherwise |
+| `InputEventValueAsString` | `(recv *types.SIMCONNECT_RECV_GET_INPUT_EVENT) (string, bool)` | Value and `true` when type is `STRING`; `("", false)` otherwise |
+
+### SetInputEvent
+
+Writes a value to an input event. Two typed variants exist:
+
+```go
+// Write a numeric value
+err := client.SetInputEventDouble(hash, 1.0)
+
+// Write a string value (truncated to 259 bytes if longer)
+err := client.SetInputEventString(hash, "some-value")
+```
+
+**Signatures:**
+
+- `SetInputEventDouble(hash uint64, value float64) error`
+- `SetInputEventString(hash uint64, value string) error`
+
+There is no response message for `SetInputEvent`. HRESULT errors are returned directly.
+
+### SubscribeInputEvent
+
+Subscribes to change notifications for a specific input event identified by hash. Notifications arrive as `SIMCONNECT_RECV_ID_SUBSCRIBE_INPUT_EVENT` messages; cast with `msg.AsSubscribeInputEvent()`.
+
+```go
+err := client.SubscribeInputEvent(hash)
+```
+
+**Signature:** `SubscribeInputEvent(hash uint64) error`
+
+Read subscription notifications using the engine helpers:
+
+```go
+if recv := msg.AsSubscribeInputEvent(); recv != nil {
+    eventHash := engine.SubscribeInputEventHash(recv)
+    if f, ok := engine.SubscribeInputEventValueAsFloat64(recv); ok {
+        fmt.Printf("Hash %d changed to %f\n", eventHash, f)
+    }
+    if s, ok := engine.SubscribeInputEventValueAsString(recv); ok {
+        fmt.Printf("Hash %d changed to %s\n", eventHash, s)
+    }
+}
+```
+
+> **Note:** `SIMCONNECT_RECV_SUBSCRIBE_INPUT_EVENT.HashBytes` is stored as `[8]byte` rather than `uint64` to avoid Go alignment padding at wire offset 12. Use `engine.SubscribeInputEventHash(recv)` rather than reading `HashBytes` directly.
+
+| Helper | Signature | Returns |
+|---|---|---|
+| `SubscribeInputEventHash` | `(recv *types.SIMCONNECT_RECV_SUBSCRIBE_INPUT_EVENT) uint64` | Event hash |
+| `SubscribeInputEventValueAsFloat64` | `(recv *types.SIMCONNECT_RECV_SUBSCRIBE_INPUT_EVENT) (float64, bool)` | Value and `true` when type is `DOUBLE` |
+| `SubscribeInputEventValueAsString` | `(recv *types.SIMCONNECT_RECV_SUBSCRIBE_INPUT_EVENT) (string, bool)` | Value and `true` when type is `STRING` |
+
+### UnsubscribeInputEvent
+
+Cancels a previous subscription.
+
+```go
+err := client.UnsubscribeInputEvent(hash)
+```
+
+**Signature:** `UnsubscribeInputEvent(hash uint64) error`
+
+### Input Event example
+
+```go
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/mrlm-net/simconnect/pkg/engine"
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+const EnumReqID uint32 = 2000
+
+func main() {
+	client := engine.New("InputEventDemo")
+	if err := client.Connect(); err != nil {
+		panic(err)
+	}
+	defer client.Disconnect()
+
+	// Step 1: enumerate all available input events
+	if err := client.EnumerateInputEvents(EnumReqID); err != nil {
+		panic(err)
+	}
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+
+	var subscribedHash uint64
+
+	for {
+		select {
+		case <-sigChan:
+			if subscribedHash != 0 {
+				client.UnsubscribeInputEvent(subscribedHash)
+			}
+			return
+		case msg, ok := <-client.Stream():
+			if !ok {
+				return
+			}
+			switch types.SIMCONNECT_RECV_ID(msg.DwID) {
+
+			case types.SIMCONNECT_RECV_ID_ENUMERATE_INPUT_EVENTS:
+				recv := msg.AsEnumerateInputEvents()
+				if recv == nil {
+					continue
+				}
+				name := engine.BytesToString(recv.RgData[0].Name[:])
+				fmt.Printf("Found input event: %s\n", name)
+				// Subscribe to the first event found
+				if subscribedHash == 0 {
+					// hash stored as uint32 in descriptor; cast for subscribe call
+					subscribedHash = uint64(recv.RgData[0].Hash)
+					client.SubscribeInputEvent(subscribedHash)
+				}
+
+			case types.SIMCONNECT_RECV_ID_SUBSCRIBE_INPUT_EVENT:
+				recv := msg.AsSubscribeInputEvent()
+				if recv == nil {
+					continue
+				}
+				hash := engine.SubscribeInputEventHash(recv)
+				if f, ok := engine.SubscribeInputEventValueAsFloat64(recv); ok {
+					fmt.Printf("Event hash %d changed: %f\n", hash, f)
+				}
+				if s, ok := engine.SubscribeInputEventValueAsString(recv); ok {
+					fmt.Printf("Event hash %d changed: %s\n", hash, s)
+				}
+			}
+		}
+	}
+}
+```
+
+---
+
+## SimObject and Livery Enumeration
+
+`EnumerateSimObjectsAndLiveries` requests a list of available aircraft models (or other object types) and their installed liveries. This is useful for building traffic injection tools or aircraft selection UIs that need to know what models the simulator has loaded.
+
+### EnumerateSimObjectsAndLiveries
+
+```go
+err := client.EnumerateSimObjectsAndLiveries(requestID, types.SIMCONNECT_SIMOBJECT_TYPE_AIRCRAFT)
+```
+
+**Signature:** `EnumerateSimObjectsAndLiveries(requestID uint32, objectType types.SIMCONNECT_SIMOBJECT_TYPE) error`
+
+| `objectType` constant | Description |
+|---|---|
+| `SIMCONNECT_SIMOBJECT_TYPE_USER` | The user aircraft |
+| `SIMCONNECT_SIMOBJECT_TYPE_ALL` | All object types |
+| `SIMCONNECT_SIMOBJECT_TYPE_AIRCRAFT` | Fixed-wing aircraft |
+| `SIMCONNECT_SIMOBJECT_TYPE_HELICOPTER` | Helicopters and rotorcraft |
+| `SIMCONNECT_SIMOBJECT_TYPE_BOAT` | Boats |
+| `SIMCONNECT_SIMOBJECT_TYPE_GROUND` | Ground vehicles |
+
+Responses arrive as one or more `SIMCONNECT_RECV_ID_ENUMERATE_SIMOBJECT_AND_LIVERY_LIST` messages. Cast each message with `msg.AsSimObjectAndLiveryEnumeration()`.
+
+### AsSimObjectAndLiveryEnumeration
+
+```go
+if recv := msg.AsSimObjectAndLiveryEnumeration(); recv != nil {
+    for _, item := range recv.RgData {
+        title := engine.BytesToString(item.AircraftTitle[:])
+        livery := engine.BytesToString(item.LiveryName[:])
+        fmt.Printf("Model: %s  Livery: %s\n", title, livery)
+    }
+}
+```
+
+`SIMCONNECT_RECV_ENUMERATE_SIMOBJECT_AND_LIVERY_LIST` embeds `SIMCONNECT_RECV_LIST_TEMPLATE`, which provides pagination fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `DwRequestID` | `DWORD` | Matches the `requestID` passed to `EnumerateSimObjectsAndLiveries` |
+| `DwArraySize` | `DWORD` | Number of entries in this response batch |
+| `DwEntryNumber` | `DWORD` | Zero-based index of the first entry in this batch |
+| `DwOutOf` | `DWORD` | Total number of entries across all batches |
+| `RgData` | `[]SIMCONNECT_ENUMERATE_SIMOBJECT_LIVERY` | Entry slice for this batch |
+
+Each `SIMCONNECT_ENUMERATE_SIMOBJECT_LIVERY` element has two fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `AircraftTitle` | `[256]byte` | Container title (matches the title in `aircraft.cfg`) |
+| `LiveryName` | `[256]byte` | Livery name, or empty if the model has no separate liveries |
+
+Use `engine.BytesToString` to convert the null-terminated byte arrays to Go strings.
+
+### Enumeration example
+
+```go
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/mrlm-net/simconnect/pkg/engine"
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+const EnumReqID uint32 = 3000
+
+func main() {
+	client := engine.New("LiveryEnum")
+	if err := client.Connect(); err != nil {
+		panic(err)
+	}
+	defer client.Disconnect()
+
+	if err := client.EnumerateSimObjectsAndLiveries(
+		EnumReqID,
+		types.SIMCONNECT_SIMOBJECT_TYPE_AIRCRAFT,
+	); err != nil {
+		panic(err)
+	}
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+
+	for {
+		select {
+		case <-sigChan:
+			return
+		case msg, ok := <-client.Stream():
+			if !ok {
+				return
+			}
+			if types.SIMCONNECT_RECV_ID(msg.DwID) != types.SIMCONNECT_RECV_ID_ENUMERATE_SIMOBJECT_AND_LIVERY_LIST {
+				continue
+			}
+			recv := msg.AsSimObjectAndLiveryEnumeration()
+			if recv == nil || recv.DwRequestID != EnumReqID {
+				continue
+			}
+			for _, item := range recv.RgData {
+				title := engine.BytesToString(item.AircraftTitle[:])
+				livery := engine.BytesToString(item.LiveryName[:])
+				fmt.Printf("%-60s  %s\n", title, livery)
+			}
+			// Stop after receiving the last batch
+			if recv.DwEntryNumber+recv.DwArraySize >= recv.DwOutOf {
+				fmt.Printf("Total: %d entries\n", recv.DwOutOf)
+				return
+			}
+		}
+	}
+}
+```
+
+---
+
+## Message Helpers Reference
+
+Every incoming `Message` from `client.Stream()` carries a `DwID` field identifying the message type. The helper methods on `Message` cast the raw pointer to a typed struct. All helpers return `nil` when `DwID` does not match the expected `SIMCONNECT_RECV_ID`.
+
+| Method | `SIMCONNECT_RECV_ID` checked | Return type |
+|---|---|---|
+| `AsOpen()` | `SIMCONNECT_RECV_ID_OPEN` | `*types.SIMCONNECT_RECV_OPEN` |
+| `AsException()` | `SIMCONNECT_RECV_ID_EXCEPTION` | `*types.SIMCONNECT_RECV_EXCEPTION` |
+| `AsEvent()` | `SIMCONNECT_RECV_ID_EVENT` | `*types.SIMCONNECT_RECV_EVENT` |
+| `AsEventFrame()` | `SIMCONNECT_RECV_ID_EVENT_FRAME` | `*types.SIMCONNECT_RECV_EVENT_FRAME` |
+| `AsEventFilename()` | `SIMCONNECT_RECV_ID_EVENT_FILENAME` | `*types.SIMCONNECT_RECV_EVENT_FILENAME` |
+| `AsEventObjectAddRemove()` | `SIMCONNECT_RECV_ID_EVENT_OBJECT_ADDREMOVE` | `*types.SIMCONNECT_RECV_EVENT_OBJECT_ADDREMOVE` |
+| `AsSimObjectData()` | `SIMCONNECT_RECV_ID_SIMOBJECT_DATA` | `*types.SIMCONNECT_RECV_SIMOBJECT_DATA` |
+| `AsSimObjectDataBType()` | `SIMCONNECT_RECV_ID_SIMOBJECT_DATA_BYTYPE` | `*types.SIMCONNECT_RECV_SIMOBJECT_DATA_BTYPE` |
+| `AsClientData()` | `SIMCONNECT_RECV_ID_CLIENT_DATA` | `*types.SIMCONNECT_RECV_CLIENT_DATA` |
+| `AsAssignedObjectID()` | `SIMCONNECT_RECV_ID_ASSIGNED_OBJECT_ID` | `*types.SIMCONNECT_RECV_ASSIGNED_OBJECT_ID` |
+| `AsFacilityData()` | `SIMCONNECT_RECV_ID_FACILITY_DATA` | `*types.SIMCONNECT_RECV_FACILITY_DATA` |
+| `AsFacilityDataEnd()` | `SIMCONNECT_RECV_ID_FACILITY_DATA_END` | `*types.SIMCONNECT_RECV_FACILITY_DATA_END` |
+| `AsFacilityList()` | `AIRPORT_LIST`, `VOR_LIST`, `NDB_LIST`, or `WAYPOINT_LIST` | `*types.SIMCONNECT_RECV_FACILITIES_LIST` |
+| `AsAirportList()` | `SIMCONNECT_RECV_ID_AIRPORT_LIST` | `*types.SIMCONNECT_RECV_AIRPORT_LIST` |
+| `AsNDBList()` | `SIMCONNECT_RECV_ID_NDB_LIST` | `*types.SIMCONNECT_RECV_NDB_LIST` |
+| `AsVORList()` | `SIMCONNECT_RECV_ID_VOR_LIST` | `*types.SIMCONNECT_RECV_VOR_LIST` |
+| `AsWaypointList()` | `SIMCONNECT_RECV_ID_WAYPOINT_LIST` | `*types.SIMCONNECT_RECV_WAYPOINT_LIST` |
+| `AsSimObjectAndLiveryEnumeration()` | `SIMCONNECT_RECV_ID_ENUMERATE_SIMOBJECT_AND_LIVERY_LIST` | `*types.SIMCONNECT_RECV_ENUMERATE_SIMOBJECT_AND_LIVERY_LIST` |
+| `AsEnumerateInputEvents()` | `SIMCONNECT_RECV_ID_ENUMERATE_INPUT_EVENTS` | `*types.SIMCONNECT_RECV_ENUMERATE_INPUT_EVENTS` |
+| `AsGetInputEvent()` | `SIMCONNECT_RECV_ID_GET_INPUT_EVENT` | `*types.SIMCONNECT_RECV_GET_INPUT_EVENT` |
+| `AsSubscribeInputEvent()` | `SIMCONNECT_RECV_ID_SUBSCRIBE_INPUT_EVENT` | `*types.SIMCONNECT_RECV_SUBSCRIBE_INPUT_EVENT` |
+| `AsFlowEvent()` | `SIMCONNECT_RECV_ID_FLOW_EVENT` | `*types.SIMCONNECT_RECV_FLOW_EVENT` |
+
+> **Note:** `AsEnumerateInputEvents()`, `AsGetInputEvent()`, `AsSubscribeInputEvent()`, and `AsFlowEvent()` are MSFS 2024 only. Calling them against MSFS 2020 will always return `nil` because the simulator never sends the corresponding `DwID` values.
+
+---
+
+## See Also
+
+- [Engine/Client Usage](usage-client.md) — Core client API: connection, data definitions, sim object requests, events, facilities, and AI traffic
+- [Client Data Areas](client-data-area.md) — Full conceptual guide and parameter reference for the Client Data Area API
+- [Manager Usage](usage-manager.md) — Automatic connection lifecycle management with auto-reconnect

--- a/docs/usage-engine-api.md
+++ b/docs/usage-engine-api.md
@@ -23,6 +23,8 @@ Client data areas are named shared memory regions that SimConnect clients use to
 
 > **See also:** [Client Data Areas](client-data-area.md) for a full conceptual guide, field-by-field parameter tables, types reference, and a complete annotated example. This section summarises the API surface and provides a self-contained writer + reader example.
 
+> **Interface note:** `CreateClientData`, `AddToClientDataDefinition`, `RequestClientData`, and `SetClientData` are methods on `*engine.Engine` (returned by `engine.New()`). They are **not** part of the `engine.Client` interface returned by `simconnect.NewClient()`. Use `engine.New()` directly when you need the Client Data Area API.
+
 ### Setup workflow
 
 A client data area is set up in four steps:

--- a/docs/usage-manager-api.md
+++ b/docs/usage-manager-api.md
@@ -80,6 +80,8 @@ import (
 func main() {
     ctx, cancel := context.WithCancel(context.Background())
 
+    mgr := manager.New("MyApp", manager.WithContext(ctx))
+
     sig := make(chan os.Signal, 1)
     signal.Notify(sig, os.Interrupt)
     go func() {
@@ -88,7 +90,6 @@ func main() {
         cancel()
     }()
 
-    mgr := manager.New("MyApp", manager.WithContext(ctx))
     if err := mgr.Start(); err != nil {
         fmt.Println("Manager stopped:", err)
     }
@@ -336,7 +337,6 @@ package main
 import (
     "fmt"
 
-    "github.com/mrlm-net/simconnect/pkg/engine"
     "github.com/mrlm-net/simconnect/pkg/manager"
 )
 
@@ -347,11 +347,10 @@ func watchOpen(mgr manager.Manager) {
     for {
         select {
         case data := <-sub.Opens():
-            appName := engine.ParseNullTerminatedString(data.SzApplicationName[:])
             fmt.Printf("Connected to: %s v%d.%d\n",
-                appName,
-                data.DwApplicationVersionMajor,
-                data.DwApplicationVersionMinor,
+                data.ApplicationName,
+                data.ApplicationVersionMajor,
+                data.ApplicationVersionMinor,
             )
         case <-sub.Done():
             return
@@ -370,15 +369,17 @@ package main
 import (
     "fmt"
 
-    "github.com/mrlm-net/simconnect/pkg/engine"
     "github.com/mrlm-net/simconnect/pkg/manager"
     "github.com/mrlm-net/simconnect/pkg/types"
 )
 
 func registerOpenHandler(mgr manager.Manager) string {
-    return mgr.OnOpen(func(data *types.SIMCONNECT_RECV_OPEN) {
-        fmt.Printf("SimConnect open: %s\n",
-            engine.ParseNullTerminatedString(data.SzApplicationName[:]))
+    return mgr.OnOpen(func(data types.ConnectionOpenData) {
+        fmt.Printf("SimConnect open: %s v%d.%d\n",
+            data.ApplicationName,
+            data.ApplicationVersionMajor,
+            data.ApplicationVersionMinor,
+        )
     })
 }
 ```
@@ -660,6 +661,8 @@ func printRanges() {
     fmt.Printf("Manager range: %d — %d\n", manager.IDRange.ManagerMin, manager.IDRange.ManagerMax)
 }
 ```
+
+> **Note:** `IDRange.UserMax` is `999,999,899` — the technical upper bound of `IsValidUserID`. However, IDs 999,999,850–999,999,899 overlap with the manager's custom event and reserved sub-ranges. Safe application IDs are `1 — 999,999,849`; treat `IDRange.UserMax` as a validation guard, not a safe upper limit for allocation.
 
 ### Organising Application IDs
 

--- a/docs/usage-manager-api.md
+++ b/docs/usage-manager-api.md
@@ -1,0 +1,810 @@
+---
+title: "Manager API Reference"
+description: "Auto-reconnect manager API: state subscriptions, custom events, and ID allocation."
+order: 3
+section: "manager"
+---
+
+# Manager API Reference
+
+This document is the API reference for the `manager` package. It covers the features that go beyond basic connection management: the Manager vs Engine trade-off, auto-reconnect lifecycle, SimState subscriptions, connection event subscriptions, custom system events, ID allocation, and state accessors.
+
+> **See also:** [Manager Usage](usage-manager.md) for full usage examples including data requests, channel-based subscriptions, and system event handlers.
+
+## Manager vs Engine
+
+The library exposes two distinct layers for connecting to SimConnect.
+
+| Concern | `engine` (direct) | `manager` (recommended) |
+|---|---|---|
+| Connection lifecycle | Manual `Connect` / `Disconnect` | Automatic with reconnect loop |
+| Auto-reconnect | No | Yes (configurable) |
+| SimState tracking | No | Yes (camera, pause, position, environment) |
+| Built-in system event subscriptions | No | Yes (Pause, Sim, Crash, View, FlightLoaded, ...) |
+| ID allocation helpers | No | Yes (`IsValidUserID`, `IsManagerID`) |
+| Concurrent subscriptions | No | Yes (channel-based, callback-based) |
+
+**Use `engine` when:**
+
+- You are writing a short-lived script or one-shot tool.
+- You need full control over the connection and message loop.
+- You do not need reconnection or SimState tracking.
+
+**Use `manager` when:**
+
+- You are building a long-running add-on that must survive simulator restarts.
+- You want automatic reconnection without writing a retry loop yourself.
+- You need SimState (camera mode, pause state, position, environment) delivered as a unified struct.
+- You want typed, channel-based subscriptions for system events.
+
+The `manager` wraps an `engine` instance internally and exposes its full API through the `Manager` interface, so you do not lose any capability by choosing it.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "github.com/mrlm-net/simconnect/pkg/manager"
+)
+
+func main() {
+    // Manager: auto-reconnect, SimState, typed subscriptions
+    mgr := manager.New("MyApp")
+
+    // Engine: single connection, manual lifecycle
+    // client := engine.New("MyApp")
+}
+```
+
+## Auto-Reconnect Lifecycle
+
+### Start and Stop
+
+`Start()` blocks and runs the connection loop. `Stop()` cancels it and waits for all subscriptions to drain.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "context"
+    "fmt"
+    "os"
+    "os/signal"
+
+    "github.com/mrlm-net/simconnect/pkg/manager"
+)
+
+func main() {
+    ctx, cancel := context.WithCancel(context.Background())
+
+    sig := make(chan os.Signal, 1)
+    signal.Notify(sig, os.Interrupt)
+    go func() {
+        <-sig
+        mgr.Stop()
+        cancel()
+    }()
+
+    mgr := manager.New("MyApp", manager.WithContext(ctx))
+    if err := mgr.Start(); err != nil {
+        fmt.Println("Manager stopped:", err)
+    }
+}
+```
+
+### Reconnect Loop Behaviour
+
+Each call to `Start()` runs the following loop:
+
+1. Enter `StateConnecting` and attempt `engine.Connect()` with a per-attempt timeout (`ConnectionTimeout`, default 30s).
+2. If the attempt fails, wait `RetryInterval` (default 15s) and retry. Repeat up to `MaxRetries` times (default 0 = unlimited).
+3. On success, enter `StateConnected` and begin dispatching messages.
+4. If the simulator closes the connection (stream channel closes), reset `SimState` to defaults, enter `StateDisconnected`.
+5. If `AutoReconnect` is `true` (default), enter `StateReconnecting`, wait `ReconnectDelay` (default 30s), and restart from step 1.
+6. If the context is cancelled at any point, `Start()` returns `context.Canceled` after draining subscriptions.
+
+### Subscription Behaviour on Reconnect
+
+Subscriptions created before `Start()` (or while connected) survive reconnections. The manager does **not** destroy and recreate channels on reconnect — the same `Subscription`, `SimStateSubscription`, `ConnectionOpenSubscription`, and `ConnectionQuitSubscription` instances remain valid across connection cycles.
+
+However, **data definitions and data requests are not automatically re-registered** after a reconnect. Re-register them inside an `OnConnectionStateChange` handler that fires when the state transitions to `StateConnected`.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "github.com/mrlm-net/simconnect/pkg/manager"
+    "github.com/mrlm-net/simconnect/pkg/types"
+)
+
+const (
+    DataDefID = 1000
+    DataReqID = 1001
+)
+
+func setupOnConnect(mgr manager.Manager) {
+    mgr.OnConnectionStateChange(func(old, new manager.ConnectionState) {
+        if new != manager.StateConnected {
+            return
+        }
+        // Re-register data definitions on every (re)connect
+        mgr.AddToDataDefinition(DataDefID, "PLANE LATITUDE", "degrees",
+            types.SIMCONNECT_DATATYPE_FLOAT64, 0, 0)
+        mgr.RequestDataOnSimObject(
+            DataReqID, DataDefID,
+            types.SIMCONNECT_OBJECT_ID_USER,
+            types.SIMCONNECT_PERIOD_SECOND,
+            types.SIMCONNECT_DATA_REQUEST_FLAG_CHANGED,
+            0, 0, 0,
+        )
+    })
+}
+```
+
+### Custom System Events on Reconnect
+
+Custom system events registered with `SubscribeToCustomSystemEvent` or `OnCustomSystemEvent` are **cleared on disconnect** and must be re-registered on the next connection. The manager resets its internal custom event ID allocator and map on every `disconnect()` call.
+
+### Stop and Shutdown Timeout
+
+`Stop()` cancels the manager context and waits for all subscriptions to call `Unsubscribe()`. If subscriptions do not drain within `ShutdownTimeout` (default 10s), `Stop()` proceeds and logs a warning.
+
+### Connection Timing Defaults
+
+| Option | Default | Description |
+|---|---|---|
+| `WithRetryInterval` | 15s | Delay between failed connection attempts |
+| `WithConnectionTimeout` | 30s | Timeout per individual connection attempt |
+| `WithReconnectDelay` | 30s | Delay before reconnecting after a disconnect |
+| `WithShutdownTimeout` | 10s | Maximum wait for subscriptions to close on stop |
+| `WithMaxRetries` | 0 (unlimited) | Maximum connection attempts before giving up |
+| `WithAutoReconnect` | true | Whether to reconnect after a disconnect |
+
+## SimState Subscriptions
+
+The manager continuously polls SimConnect for a large set of simulator variables and aggregates them into a `SimState` struct. Changes to significant fields (discrete state, not continuous telemetry) are broadcast to all SimState subscribers.
+
+### SimState Struct
+
+`SimState` is a flat value struct (no pointers). Compare two values with `==` or use the `Equal` method, which ignores continuously changing fields (time, position, weather, speed) and only compares discrete state fields.
+
+Key field groups:
+
+| Group | Fields |
+|---|---|
+| Camera | `Camera` (`CameraState`), `Substate` (`CameraSubstate`), `SmartCameraActive` |
+| Simulation control | `Paused`, `SimRunning`, `SimDisabled`, `SimulationRate`, `UserInputEnabled` |
+| Crash and sound | `Crashed`, `CrashReset`, `Sound` |
+| Realism | `Realism`, `RealismCrashDetection`, `RealismCrashWithOthers` |
+| Rendering mode | `IsInVR`, `IsUsingMotionControllers`, `IsUsingJoystickThrottle`, `TrackIREnabled` |
+| Session type | `IsInRTC`, `IsAvatar`, `IsAircraft`, `IsOnGround` |
+| Avatar | `HandAnimState`, `HideAvatarInAircraft`, `ParachuteOpen` |
+| Mission | `MissionScore` |
+| Time (sim) | `SimulationTime`, `LocalTime`, `ZuluTime` |
+| Date (local/Zulu) | `LocalDay`, `LocalMonth`, `LocalYear`, `ZuluDay`, `ZuluMonth`, `ZuluYear` |
+| Position | `Latitude`, `Longitude`, `Altitude`, `IndicatedAltitude` |
+| Attitude | `TrueHeading`, `MagneticHeading`, `Pitch`, `Bank` |
+| Speed | `GroundSpeed`, `IndicatedAirspeed`, `TrueAirspeed`, `VerticalSpeed` |
+| Environment | `AmbientTemperature`, `AmbientPressure`, `AmbientWindVelocity`, `AmbientWindDirection`, `AmbientVisibility`, `AmbientInCloud`, `AmbientPrecipState`, `AmbientInSmoke`, `EnvSmokeDensity`, `EnvCloudDensity` |
+| Pressure and ground | `BarometerPressure`, `SeaLevelPressure`, `SeaLevelAmbientTemperature`, `GroundAltitude`, `MagVar`, `SurfaceType`, `DensityAltitude` |
+| Sun and timezone | `ZuluSunriseTime`, `ZuluSunsetTime`, `TimeZoneOffset` |
+| Units | `TooltipUnits`, `UnitsOfMeasure`, `VisualModelRadius` |
+
+The full field list is defined in `pkg/manager/state.go`.
+
+### Polling Frequency
+
+The manager polls SimState at `SIMCONNECT_PERIOD_SIM_FRAME` by default (every sim frame, ~30-60 Hz). Use `WithSimStatePeriod` to reduce frequency if CPU usage matters:
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "github.com/mrlm-net/simconnect/pkg/manager"
+    "github.com/mrlm-net/simconnect/pkg/types"
+)
+
+func main() {
+    mgr := manager.New("MyApp",
+        // Poll SimState once per second instead of every frame
+        manager.WithSimStatePeriod(types.SIMCONNECT_PERIOD_SECOND),
+    )
+    _ = mgr
+}
+```
+
+Supported values: `SIMCONNECT_PERIOD_SIM_FRAME`, `SIMCONNECT_PERIOD_VISUAL_FRAME`, `SIMCONNECT_PERIOD_SECOND`, `SIMCONNECT_PERIOD_ONCE`, `SIMCONNECT_PERIOD_NEVER`.
+
+### OnSimStateChange (Callback)
+
+Register a callback that fires when any significant SimState field changes. The callback receives both the old and new state.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+
+    "github.com/mrlm-net/simconnect/pkg/manager"
+)
+
+func main() {
+    mgr := manager.New("MyApp")
+
+    id := mgr.OnSimStateChange(func(old, new manager.SimState) {
+        if old.Paused != new.Paused {
+            if new.Paused {
+                fmt.Println("Simulator paused")
+            } else {
+                fmt.Println("Simulator resumed")
+            }
+        }
+        if old.Camera != new.Camera {
+            fmt.Printf("Camera: %v -> %v\n", old.Camera, new.Camera)
+        }
+        if old.Crashed != new.Crashed && new.Crashed {
+            fmt.Println("Crash detected")
+        }
+    })
+
+    // Remove when done
+    mgr.RemoveSimStateChange(id)
+    _ = mgr
+}
+```
+
+### SubscribeSimStateChange (Channel)
+
+For goroutine-based processing, use the channel subscription. Each `SimStateChange` carries both the previous and new state.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+
+    "github.com/mrlm-net/simconnect/pkg/manager"
+)
+
+func watchSimState(mgr manager.Manager) {
+    sub := mgr.SubscribeSimStateChange("sim-state-watcher", 10)
+    defer sub.Unsubscribe()
+
+    for {
+        select {
+        case change := <-sub.SimStateChanges():
+            if change.OldState.SimRunning != change.NewState.SimRunning {
+                fmt.Printf("SimRunning changed to %v\n", change.NewState.SimRunning)
+            }
+        case <-sub.Done():
+            return
+        }
+    }
+}
+```
+
+### SimStateSubscription Interface
+
+| Method | Returns | Description |
+|---|---|---|
+| `ID()` | `string` | Subscription identifier |
+| `SimStateChanges()` | `<-chan SimStateChange` | Channel receiving state transitions |
+| `Done()` | `<-chan struct{}` | Closed when subscription ends |
+| `Unsubscribe()` | — | Cancels the subscription and closes channels |
+
+### GetSimStateSubscription
+
+Retrieves an existing SimState subscription by ID. Returns `nil` if not found.
+
+```go
+//go:build windows
+
+package main
+
+import "github.com/mrlm-net/simconnect/pkg/manager"
+
+func example(mgr manager.Manager) {
+    if sub := mgr.GetSimStateSubscription("sim-state-watcher"); sub != nil {
+        // subscription is still active
+        _ = sub
+    }
+}
+```
+
+## Connection Event Subscriptions
+
+The manager fires events when the underlying SimConnect connection opens and when the simulator closes it. These are distinct from the connection state transitions: `OnOpen` fires when the SimConnect handshake completes (containing simulator version info), and `OnQuit` fires when the simulator signals it is shutting down.
+
+### SubscribeOnOpen (Channel)
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+
+    "github.com/mrlm-net/simconnect/pkg/engine"
+    "github.com/mrlm-net/simconnect/pkg/manager"
+)
+
+func watchOpen(mgr manager.Manager) {
+    sub := mgr.SubscribeOnOpen("open-watcher", 5)
+    defer sub.Unsubscribe()
+
+    for {
+        select {
+        case data := <-sub.Opens():
+            appName := engine.ParseNullTerminatedString(data.SzApplicationName[:])
+            fmt.Printf("Connected to: %s v%d.%d\n",
+                appName,
+                data.DwApplicationVersionMajor,
+                data.DwApplicationVersionMinor,
+            )
+        case <-sub.Done():
+            return
+        }
+    }
+}
+```
+
+### OnOpen (Callback)
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+
+    "github.com/mrlm-net/simconnect/pkg/engine"
+    "github.com/mrlm-net/simconnect/pkg/manager"
+    "github.com/mrlm-net/simconnect/pkg/types"
+)
+
+func registerOpenHandler(mgr manager.Manager) string {
+    return mgr.OnOpen(func(data *types.SIMCONNECT_RECV_OPEN) {
+        fmt.Printf("SimConnect open: %s\n",
+            engine.ParseNullTerminatedString(data.SzApplicationName[:]))
+    })
+}
+```
+
+Remove with `mgr.RemoveOpen(id)`.
+
+### SubscribeOnQuit (Channel)
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+
+    "github.com/mrlm-net/simconnect/pkg/manager"
+)
+
+func watchQuit(mgr manager.Manager) {
+    sub := mgr.SubscribeOnQuit("quit-watcher", 5)
+    defer sub.Unsubscribe()
+
+    for {
+        select {
+        case <-sub.Quits():
+            fmt.Println("Simulator quit")
+        case <-sub.Done():
+            return
+        }
+    }
+}
+```
+
+### OnQuit (Callback)
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+
+    "github.com/mrlm-net/simconnect/pkg/manager"
+)
+
+func registerQuitHandler(mgr manager.Manager) string {
+    return mgr.OnQuit(func() {
+        fmt.Println("Simulator quit")
+    })
+}
+```
+
+Remove with `mgr.RemoveQuit(id)`.
+
+### ConnectionOpenSubscription Interface
+
+| Method | Returns | Description |
+|---|---|---|
+| `ID()` | `string` | Subscription identifier |
+| `Opens()` | `<-chan types.ConnectionOpenData` | Channel receiving open events |
+| `Done()` | `<-chan struct{}` | Closed when subscription ends |
+| `Unsubscribe()` | — | Cancels the subscription |
+
+### ConnectionQuitSubscription Interface
+
+| Method | Returns | Description |
+|---|---|---|
+| `ID()` | `string` | Subscription identifier |
+| `Quits()` | `<-chan types.ConnectionQuitData` | Channel receiving quit events |
+| `Done()` | `<-chan struct{}` | Closed when subscription ends |
+| `Unsubscribe()` | — | Cancels the subscription |
+
+### GetOpenSubscription / GetQuitSubscription
+
+Retrieve an existing subscription by ID, or `nil` if not found.
+
+```go
+//go:build windows
+
+package main
+
+import "github.com/mrlm-net/simconnect/pkg/manager"
+
+func example(mgr manager.Manager) {
+    openSub := mgr.GetOpenSubscription("open-watcher")
+    quitSub := mgr.GetQuitSubscription("quit-watcher")
+    _, _ = openSub, quitSub
+}
+```
+
+## Custom System Events
+
+The manager handles a fixed set of system events internally (Pause, Sim, Crashed, CrashReset, Sound, View, FlightLoaded, AircraftLoaded, FlightPlanActivated, FlightPlanDeactivated, ObjectAdded, ObjectRemoved). For any other SimConnect system event not on that list, use the custom system event API.
+
+### Reserved Event Names
+
+The following names cannot be used with the custom event API — they are managed internally:
+
+`Pause`, `Sim`, `Crashed`, `CrashReset`, `Sound`, `View`, `FlightLoaded`, `AircraftLoaded`, `FlightPlanActivated`, `FlightPlanDeactivated`, `ObjectAdded`, `ObjectRemoved`
+
+Attempting to subscribe to a reserved name returns `ErrReservedEventName`.
+
+### SubscribeToCustomSystemEvent
+
+Creates a channel subscription for a named SimConnect system event. Returns a `Subscription` that delivers raw `engine.Message` values. Calling this for the same event name a second time returns a new subscription against the already-registered event — the SimConnect subscription is shared.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/mrlm-net/simconnect/pkg/manager"
+    "github.com/mrlm-net/simconnect/pkg/types"
+)
+
+func subscribe6Hz(mgr manager.Manager) {
+    sub, err := mgr.SubscribeToCustomSystemEvent("6Hz", 10)
+    if err != nil {
+        log.Printf("subscribe failed: %v", err)
+        return
+    }
+    defer sub.Unsubscribe()
+
+    for {
+        select {
+        case msg := <-sub.Messages():
+            if types.SIMCONNECT_RECV_ID(msg.DwID) == types.SIMCONNECT_RECV_ID_EVENT {
+                ev := msg.AsEvent()
+                fmt.Printf("6Hz tick: data=%d\n", ev.DwData)
+            }
+        case <-sub.Done():
+            return
+        }
+    }
+}
+```
+
+### OnCustomSystemEvent
+
+Registers a callback handler for a named system event. The event must be subscribed first (either via `SubscribeToCustomSystemEvent` or a prior `OnCustomSystemEvent` call). Returns a handler ID that can be used to remove the handler.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/mrlm-net/simconnect/pkg/manager"
+)
+
+// CustomSystemEventHandler is: func(eventName string, data uint32)
+type CustomSystemEventHandler = manager.CustomSystemEventHandler
+
+func register6HzCallback(mgr manager.Manager) {
+    // SubscribeToCustomSystemEvent registers the SimConnect subscription;
+    // OnCustomSystemEvent registers a typed callback on top of it.
+    _, err := mgr.SubscribeToCustomSystemEvent("6Hz", 4)
+    if err != nil {
+        log.Printf("subscribe failed: %v", err)
+        return
+    }
+
+    id, err := mgr.OnCustomSystemEvent("6Hz", func(eventName string, data uint32) {
+        fmt.Printf("[%s] fired: data=%d\n", eventName, data)
+    })
+    if err != nil {
+        log.Printf("handler registration failed: %v", err)
+        return
+    }
+
+    // Remove handler by ID when done
+    if err := mgr.RemoveCustomSystemEvent("6Hz", id); err != nil {
+        log.Printf("remove handler failed: %v", err)
+    }
+}
+```
+
+### UnsubscribeFromCustomSystemEvent
+
+Removes the SimConnect system event subscription entirely and clears all associated handlers.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "log"
+
+    "github.com/mrlm-net/simconnect/pkg/manager"
+)
+
+func unsubscribe6Hz(mgr manager.Manager) {
+    if err := mgr.UnsubscribeFromCustomSystemEvent("6Hz"); err != nil {
+        log.Printf("unsubscribe failed: %v", err)
+    }
+}
+```
+
+### Custom Event ID Limit
+
+The manager allocates IDs for custom events from a reserved sub-range: 999,999,850 to 999,999,886 (37 slots). Subscribing to more than 37 distinct custom event names in a single connection cycle returns `ErrCustomEventIDExhausted`. The allocator resets on every disconnect.
+
+### Error Values
+
+| Error | Meaning |
+|---|---|
+| `ErrReservedEventName` | Event name is reserved for internal use |
+| `ErrCustomEventNotFound` | Event was not subscribed |
+| `ErrCustomEventIDExhausted` | All 37 custom event ID slots are in use |
+| `ErrCustomEventNotSubscribed` | Tried to add a callback before subscribing |
+| `ErrCustomEventHandlerNotFound` | Handler ID not found for removal |
+
+## ID Allocation
+
+SimConnect requires every data definition, data request, and system event subscription to carry a numeric ID. The manager reserves the top of the `uint32` space for its own operations so that application code can start from 1 without any coordination.
+
+### ID Ranges
+
+| Range | Owner | Slots |
+|---|---|---|
+| 1 — 999,999,849 | User application | 999,999,849 |
+| 999,999,850 — 999,999,886 | Manager (custom events) | 37 |
+| 999,999,887 — 999,999,899 | Reserved (unallocated) | 13 |
+| 999,999,900 — 999,999,999 | Manager (internal) | 100 |
+
+### Validation Helpers
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/mrlm-net/simconnect/pkg/manager"
+)
+
+const MyDataDefID uint32 = 1000
+
+func validateIDs() {
+    if !manager.IsValidUserID(MyDataDefID) {
+        log.Fatalf("ID %d conflicts with the manager's reserved range", MyDataDefID)
+    }
+
+    // Distinguish user vs manager IDs at runtime
+    if manager.IsManagerID(999999900) {
+        fmt.Println("ID 999999900 is reserved for the manager")
+    }
+}
+```
+
+`IDRange` exposes the boundaries as a variable if you need them programmatically:
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+
+    "github.com/mrlm-net/simconnect/pkg/manager"
+)
+
+func printRanges() {
+    fmt.Printf("User range: %d — %d\n", manager.IDRange.UserMin, manager.IDRange.UserMax)
+    fmt.Printf("Manager range: %d — %d\n", manager.IDRange.ManagerMin, manager.IDRange.ManagerMax)
+}
+```
+
+### Organising Application IDs
+
+Pick non-overlapping sub-ranges for each concern in your application:
+
+```go
+//go:build windows
+
+package main
+
+const (
+    // Aircraft telemetry — 1000-1099
+    AircraftPositionDefID uint32 = 1000
+    AircraftPositionReqID uint32 = 1001
+    AircraftVelocityDefID uint32 = 1002
+    AircraftVelocityReqID uint32 = 1003
+
+    // Environment — 2000-2099
+    WeatherDefID uint32 = 2000
+    WeatherReqID uint32 = 2001
+
+    // Traffic — 3000-3099
+    TrafficDefID uint32 = 3000
+    TrafficReqID uint32 = 3001
+)
+```
+
+> **Note:** Do not use IDs in the range 999,999,850 — 999,999,999. The manager uses those ranges internally; overlapping with them will silently corrupt your data definitions or event subscriptions.
+
+## State Accessors
+
+The manager exposes several read-only accessors for querying current state without subscribing to change events.
+
+### ConnectionState
+
+Returns the current connection state as a `ConnectionState` value.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+
+    "github.com/mrlm-net/simconnect/pkg/manager"
+)
+
+func printConnectionState(mgr manager.Manager) {
+    switch mgr.ConnectionState() {
+    case manager.StateDisconnected:
+        fmt.Println("Disconnected")
+    case manager.StateConnecting:
+        fmt.Println("Connecting...")
+    case manager.StateConnected:
+        fmt.Println("Connected")
+    case manager.StateReconnecting:
+        fmt.Println("Reconnecting...")
+    }
+}
+```
+
+### SimState
+
+Returns a snapshot of the current `SimState`. The snapshot is a copy; it does not update as the simulator changes.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+
+    "github.com/mrlm-net/simconnect/pkg/manager"
+)
+
+func printSimState(mgr manager.Manager) {
+    s := mgr.SimState()
+    fmt.Printf("Paused: %v, SimRunning: %v, Camera: %v\n",
+        s.Paused, s.SimRunning, s.Camera)
+    fmt.Printf("Position: %.4f, %.4f @ %.0f ft\n",
+        s.Latitude, s.Longitude, s.Altitude)
+}
+```
+
+### Client
+
+Returns the underlying `engine.Client` when connected, or `nil` when disconnected. Use this for operations not exposed directly on the `Manager` interface.
+
+```go
+//go:build windows
+
+package main
+
+import "github.com/mrlm-net/simconnect/pkg/manager"
+
+func useClient(mgr manager.Manager) {
+    if client := mgr.Client(); client != nil {
+        // Direct engine access when needed
+        _ = client
+    }
+}
+```
+
+### Configuration Getters
+
+Inspect the manager's configuration at runtime.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "fmt"
+
+    "github.com/mrlm-net/simconnect/pkg/manager"
+)
+
+func printConfig(mgr manager.Manager) {
+    fmt.Printf("AutoReconnect:     %v\n", mgr.IsAutoReconnect())
+    fmt.Printf("RetryInterval:     %v\n", mgr.RetryInterval())
+    fmt.Printf("ConnectionTimeout: %v\n", mgr.ConnectionTimeout())
+    fmt.Printf("ReconnectDelay:    %v\n", mgr.ReconnectDelay())
+    fmt.Printf("ShutdownTimeout:   %v\n", mgr.ShutdownTimeout())
+    fmt.Printf("MaxRetries:        %d\n", mgr.MaxRetries())
+    fmt.Printf("SimStatePeriod:    %v\n", mgr.SimStatePeriod())
+}
+```
+
+| Accessor | Returns | Description |
+|---|---|---|
+| `IsAutoReconnect()` | `bool` | Whether auto-reconnect is enabled |
+| `RetryInterval()` | `time.Duration` | Delay between connection attempts |
+| `ConnectionTimeout()` | `time.Duration` | Timeout per connection attempt |
+| `ReconnectDelay()` | `time.Duration` | Delay before reconnecting after disconnect |
+| `ShutdownTimeout()` | `time.Duration` | Maximum wait for subscription drain on stop |
+| `MaxRetries()` | `int` | Connection attempt limit (0 = unlimited) |
+| `SimStatePeriod()` | `types.SIMCONNECT_PERIOD` | Configured SimState poll frequency |
+
+## See Also
+
+- [Manager Usage](usage-manager.md) — Full usage examples: data requests, system event handlers, channel subscriptions
+- [Manager Configuration](config-manager.md) — All configuration options and their defaults
+- [Request ID Management](manager-requests-ids.md) — Detailed ID range documentation and conflict resolution
+- [Engine/Client Usage](usage-client.md) — Direct engine client API (no reconnect)
+- [Event Lifecycle](events-lifecycle.md) — Full event dispatch architecture reference

--- a/docs/usage-manager.md
+++ b/docs/usage-manager.md
@@ -1,7 +1,7 @@
 ---
 title: "Manager Usage"
 description: "Complete API for robust long-running SimConnect applications."
-order: 4
+order: 2
 section: "manager"
 ---
 


### PR DESCRIPTION
## Summary

Closes #151 — documentation enrichment epic for v0.5.0.

- Add 7 new documentation guides covering getting started, engine API, manager API, AI traffic, facilities, and MSFS 2024 input events
- Fix missing `section: client` frontmatter on `usage-datasets.md`
- Resolve all navigation order conflicts in `section: client` and `section: manager`
- Website builds cleanly with all 7 new doc routes confirmed

## New docs

| File | Issue | Section | Order |
|------|-------|---------|-------|
| `docs/getting-started.md` | #152 | client | 1 |
| `docs/usage-engine-api.md` | #154 | client | 5 |
| `docs/guide-traffic.md` | #156 | client | 7 |
| `docs/guide-facilities.md` | #157 | client | 8 |
| `docs/guide-input-events.md` | #158 | client | 9 |
| `docs/usage-manager-api.md` | #155 | manager | 3 |

## Fixes

| File | Issue | Change |
|------|-------|--------|
| `docs/usage-datasets.md` | #153 | Add `section: client` (was missing) |
| `docs/config-client.md` | #159 | order 1→2 |
| `docs/usage-client.md` | #159 | order 2→3 |
| `docs/client-data-area.md` | #159 | order 5→6 |
| `docs/config-manager.md` | #159 | order 3→1 |
| `docs/usage-manager.md` | #159 | order 4→2 |

## Test plan

- [x] `npm run build` in `website/` exits 0
- [x] All 7 new routes present in `website/build/docs/`
- [x] No duplicate `order` values within any section
- [ ] Review gate: #160