### PR TITLE
fix(datasets,manager): align unit strings — AMBIENT PRESSURE and VERTICAL SPEED (#226)

### DIFF
--- a/docs/manager-requests-ids.md
+++ b/docs/manager-requests-ids.md
@@ -58,7 +58,7 @@ The manager's simulator state data definition now includes additional environmen
 - `PLANE LATITUDE` (Degrees), `PLANE LONGITUDE` (Degrees), `PLANE ALTITUDE` (Feet), `INDICATED ALTITUDE` (Feet)
 - `PLANE HEADING DEGREES TRUE` (Degrees), `PLANE HEADING DEGREES MAGNETIC` (Degrees)
 - `PLANE PITCH DEGREES` (Degrees), `PLANE BANK DEGREES` (Degrees)
-- `GROUND VELOCITY` (Knots), `AIRSPEED INDICATED` (Knots), `AIRSPEED TRUE` (Knots), `VERTICAL SPEED` (Feet per second)
+- `GROUND VELOCITY` (Knots), `AIRSPEED INDICATED` (Knots), `AIRSPEED TRUE` (Knots), `VERTICAL SPEED` (Feet per minute)
 - `SMART CAMERA ACTIVE` (Boolean)
 - `HAND ANIM STATE` (Number, 0-12 frame IDs), `HIDE AVATAR IN AIRCRAFT` (Boolean), `MISSION SCORE` (Number), `PARACHUTE OPEN` (Boolean)
 - `ZULU SUNRISE TIME` (Seconds), `ZULU SUNSET TIME` (Seconds), `TIME ZONE OFFSET` (Seconds)

--- a/docs/usage-datasets.md
+++ b/docs/usage-datasets.md
@@ -121,7 +121,7 @@ Import path: `github.com/mrlm-net/simconnect/pkg/datasets/environment`
 | Field | SimVar | Unit |
 |---|---|---|
 | `Temperature` | `AMBIENT TEMPERATURE` | celsius |
-| `Pressure` | `AMBIENT PRESSURE` | millibars |
+| `Pressure` | `AMBIENT PRESSURE` | inHg |
 | `WindDirection` | `AMBIENT WIND DIRECTION` | degrees |
 | `WindVelocity` | `AMBIENT WIND VELOCITY` | knots |
 | `Visibility` | `AMBIENT VISIBILITY` | meters |

--- a/docs/usage-manager.md
+++ b/docs/usage-manager.md
@@ -726,7 +726,7 @@ fmt.Printf("Camera: %v, Paused: %v, Crashed: %v\n", state.Camera, state.Paused, 
 | `GroundSpeed` | `float64` | Ground velocity (Knots) |
 | `IndicatedAirspeed` | `float64` | Indicated airspeed (Knots) |
 | `TrueAirspeed` | `float64` | True airspeed (Knots) |
-| `VerticalSpeed` | `float64` | Vertical speed (Feet per second) |
+| `VerticalSpeed` | `float64` | Vertical speed (Feet per minute) |
 | `SmartCameraActive` | `bool` | Whether smart camera is active |
 | `HandAnimState` | `int32` | Hand animation state (Enum: 0-12 frame IDs) |
 | `HideAvatarInAircraft` | `bool` | Whether avatar is hidden in aircraft |

--- a/examples/ai-traffic/main.go
+++ b/examples/ai-traffic/main.go
@@ -306,7 +306,7 @@ func addPlanesRequestDataset(client engine.Client) {
 	client.AddToDataDefinition(3000, "PLANE ALTITUDE", "feet", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 6)
 	client.AddToDataDefinition(3000, "PLANE HEADING DEGREES TRUE", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 7)
 	client.AddToDataDefinition(3000, "PLANE HEADING DEGREES MAGNETIC", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 8)
-	client.AddToDataDefinition(3000, "VERTICAL SPEED", "feet per second", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 9)
+	client.AddToDataDefinition(3000, "VERTICAL SPEED", "feet per minute", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 9)
 	client.AddToDataDefinition(3000, "PLANE PITCH DEGREES", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 10)
 	client.AddToDataDefinition(3000, "PLANE BANK DEGREES", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 11)
 	client.AddToDataDefinition(3000, "GROUND VELOCITY", "knots", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 12)

--- a/examples/locate-airport/main.go
+++ b/examples/locate-airport/main.go
@@ -77,7 +77,7 @@ connected:
 	client.AddToDataDefinition(3000, "PLANE ALTITUDE", "feet", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 5)
 	client.AddToDataDefinition(3000, "PLANE HEADING DEGREES TRUE", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 6)
 	client.AddToDataDefinition(3000, "PLANE HEADING DEGREES MAGNETIC", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 7)
-	client.AddToDataDefinition(3000, "VERTICAL SPEED", "feet per second", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 8)
+	client.AddToDataDefinition(3000, "VERTICAL SPEED", "feet per minute", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 8)
 	client.AddToDataDefinition(3000, "PLANE PITCH DEGREES", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 9)
 	client.AddToDataDefinition(3000, "PLANE BANK DEGREES", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 10)
 	client.AddToDataDefinition(3000, "GROUND VELOCITY", "knots", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 11)

--- a/examples/monitor-traffic/main.go
+++ b/examples/monitor-traffic/main.go
@@ -262,7 +262,7 @@ func addPlanesRequestDataset(client engine.Client) {
 	client.AddToDataDefinition(3000, "PLANE ALTITUDE", "feet", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 6)
 	client.AddToDataDefinition(3000, "PLANE HEADING DEGREES TRUE", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 7)
 	client.AddToDataDefinition(3000, "PLANE HEADING DEGREES MAGNETIC", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 8)
-	client.AddToDataDefinition(3000, "VERTICAL SPEED", "feet per second", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 9)
+	client.AddToDataDefinition(3000, "VERTICAL SPEED", "feet per minute", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 9)
 	client.AddToDataDefinition(3000, "PLANE PITCH DEGREES", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 10)
 	client.AddToDataDefinition(3000, "PLANE BANK DEGREES", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 11)
 	client.AddToDataDefinition(3000, "GROUND VELOCITY", "knots", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 12)

--- a/examples/read-messages/main.go
+++ b/examples/read-messages/main.go
@@ -77,7 +77,7 @@ connected:
 	client.AddToDataDefinition(3000, "PLANE ALTITUDE", "feet", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 5)
 	client.AddToDataDefinition(3000, "PLANE HEADING DEGREES TRUE", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 6)
 	client.AddToDataDefinition(3000, "PLANE HEADING DEGREES MAGNETIC", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 7)
-	client.AddToDataDefinition(3000, "VERTICAL SPEED", "feet per second", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 8)
+	client.AddToDataDefinition(3000, "VERTICAL SPEED", "feet per minute", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 8)
 	client.AddToDataDefinition(3000, "PLANE PITCH DEGREES", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 9)
 	client.AddToDataDefinition(3000, "PLANE BANK DEGREES", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 10)
 	client.AddToDataDefinition(3000, "GROUND VELOCITY", "knots", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 11)

--- a/examples/simconnect-benchmark/main.go
+++ b/examples/simconnect-benchmark/main.go
@@ -92,7 +92,7 @@ func setupDataDefinitions(client engine.Client) {
 	client.AddToDataDefinition(3000, "PLANE ALTITUDE", "feet", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 5)
 	client.AddToDataDefinition(3000, "PLANE HEADING DEGREES TRUE", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 6)
 	client.AddToDataDefinition(3000, "PLANE HEADING DEGREES MAGNETIC", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 7)
-	client.AddToDataDefinition(3000, "VERTICAL SPEED", "feet per second", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 8)
+	client.AddToDataDefinition(3000, "VERTICAL SPEED", "feet per minute", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 8)
 	client.AddToDataDefinition(3000, "PLANE PITCH DEGREES", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 9)
 	client.AddToDataDefinition(3000, "PLANE BANK DEGREES", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 10)
 	client.AddToDataDefinition(3000, "GROUND VELOCITY", "knots", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 11)

--- a/examples/simconnect-manager/main.go
+++ b/examples/simconnect-manager/main.go
@@ -68,7 +68,7 @@ func setupDataDefinitions(client engine.Client) {
 	client.AddToDataDefinition(3000, "PLANE ALTITUDE", "feet", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 5)
 	client.AddToDataDefinition(3000, "PLANE HEADING DEGREES TRUE", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 6)
 	client.AddToDataDefinition(3000, "PLANE HEADING DEGREES MAGNETIC", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 7)
-	client.AddToDataDefinition(3000, "VERTICAL SPEED", "feet per second", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 8)
+	client.AddToDataDefinition(3000, "VERTICAL SPEED", "feet per minute", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 8)
 	client.AddToDataDefinition(3000, "PLANE PITCH DEGREES", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 9)
 	client.AddToDataDefinition(3000, "PLANE BANK DEGREES", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 10)
 	client.AddToDataDefinition(3000, "GROUND VELOCITY", "knots", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 11)

--- a/examples/simconnect-state/main.go
+++ b/examples/simconnect-state/main.go
@@ -87,7 +87,7 @@ func setupDataDefinitions(client engine.Client) {
 	client.AddToDataDefinition(3000, "PLANE ALTITUDE", "feet", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 5)
 	client.AddToDataDefinition(3000, "PLANE HEADING DEGREES TRUE", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 6)
 	client.AddToDataDefinition(3000, "PLANE HEADING DEGREES MAGNETIC", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 7)
-	client.AddToDataDefinition(3000, "VERTICAL SPEED", "feet per second", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 8)
+	client.AddToDataDefinition(3000, "VERTICAL SPEED", "feet per minute", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 8)
 	client.AddToDataDefinition(3000, "PLANE PITCH DEGREES", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 9)
 	client.AddToDataDefinition(3000, "PLANE BANK DEGREES", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 10)
 	client.AddToDataDefinition(3000, "GROUND VELOCITY", "knots", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 11)

--- a/examples/simconnect-subscribe/main.go
+++ b/examples/simconnect-subscribe/main.go
@@ -68,7 +68,7 @@ func setupDataDefinitions(client engine.Client) {
 	client.AddToDataDefinition(3000, "PLANE ALTITUDE", "feet", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 5)
 	client.AddToDataDefinition(3000, "PLANE HEADING DEGREES TRUE", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 6)
 	client.AddToDataDefinition(3000, "PLANE HEADING DEGREES MAGNETIC", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 7)
-	client.AddToDataDefinition(3000, "VERTICAL SPEED", "feet per second", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 8)
+	client.AddToDataDefinition(3000, "VERTICAL SPEED", "feet per minute", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 8)
 	client.AddToDataDefinition(3000, "PLANE PITCH DEGREES", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 9)
 	client.AddToDataDefinition(3000, "PLANE BANK DEGREES", "degrees", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 10)
 	client.AddToDataDefinition(3000, "GROUND VELOCITY", "knots", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 11)

--- a/pkg/datasets/environment/main.go
+++ b/pkg/datasets/environment/main.go
@@ -13,7 +13,7 @@ func NewWeatherDataset() *datasets.DataSet {
 	return &datasets.DataSet{
 		Definitions: []datasets.DataDefinition{
 			{Name: "AMBIENT TEMPERATURE", Unit: "celsius", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
-			{Name: "AMBIENT PRESSURE", Unit: "millibars", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
+			{Name: "AMBIENT PRESSURE", Unit: "inHg", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
 			{Name: "AMBIENT WIND DIRECTION", Unit: "degrees", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
 			{Name: "AMBIENT WIND VELOCITY", Unit: "knots", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},
 			{Name: "AMBIENT VISIBILITY", Unit: "meters", Type: types.SIMCONNECT_DATATYPE_FLOAT64, Epsilon: 0},

--- a/pkg/manager/simstate_registration.go
+++ b/pkg/manager/simstate_registration.go
@@ -227,7 +227,7 @@ func (m *Instance) registerSimStateSubscriptions(client engine.Client) {
 	if err := client.AddToDataDefinition(m.cameraDefinitionID, "AIRSPEED TRUE", "knots", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 48); err != nil {
 		m.logger.Error("[manager] Failed to add AIRSPEED TRUE definition", "error", err)
 	}
-	if err := client.AddToDataDefinition(m.cameraDefinitionID, "VERTICAL SPEED", "feet per second", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 49); err != nil {
+	if err := client.AddToDataDefinition(m.cameraDefinitionID, "VERTICAL SPEED", "feet per minute", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 49); err != nil {
 		m.logger.Error("[manager] Failed to add VERTICAL SPEED definition", "error", err)
 	}
 	if err := client.AddToDataDefinition(m.cameraDefinitionID, "SMART CAMERA ACTIVE", "", types.SIMCONNECT_DATATYPE_FLOAT64, 0, 50); err != nil {

--- a/pkg/manager/state.go
+++ b/pkg/manager/state.go
@@ -68,7 +68,7 @@ type SimState struct {
 	GroundSpeed       float64 // GROUND VELOCITY (knots)
 	IndicatedAirspeed float64 // AIRSPEED INDICATED (knots)
 	TrueAirspeed      float64 // AIRSPEED TRUE (knots)
-	VerticalSpeed     float64 // VERTICAL SPEED (feet per second)
+	VerticalSpeed     float64 // VERTICAL SPEED (feet per minute)
 	// Camera extended
 	SmartCameraActive bool // SMART CAMERA ACTIVE
 	// Miscellaneous


### PR DESCRIPTION
## Summary

Closes #226 — unit string audit and alignment for v0.5.0.

Full audit found 7 mismatches between `pkg/datasets/` and `pkg/manager/simstate_registration.go`. Two are semantic scale errors (fixed here); five are case-only cosmetic differences (SimConnect is case-insensitive, no action needed).

## Changes

| File | Change | Breaking |
|------|--------|---------|
| `pkg/datasets/environment/main.go` | `AMBIENT PRESSURE`: `"millibars"` → `"inHg"` | No |
| `pkg/manager/simstate_registration.go` | `VERTICAL SPEED`: `"feet per second"` → `"feet per minute"` | **Yes** |
| `pkg/manager/state.go` | Comment: `(feet per second)` → `(feet per minute)` | No |

## Breaking Change

`SimState.VerticalSpeed` values will be **60× larger** after this fix. Any consumer reading `SimState.VerticalSpeed` and assuming feet/second must be updated. Standard aviation VSI unit is feet per minute; all `pkg/datasets/aircraft` and `pkg/datasets/traffic` already use this unit.

## Non-breaking

`WeatherDataset.Pressure` (from `NewWeatherDataset()`) changes from millibars to inHg. Dataset structs are populated by direct SimConnect request per connection, so no cached values are affected.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet -unsafeptr=false ./...` passes
- [x] `go test ./...` passes
- [x] Verified no other semantic unit mismatches remain in pkg/datasets/ vs pkg/manager/