### PR TITLE
feat(simvar-cli): watch command, structured output, TOML config

### DIFF
--- a/docs/simvar-cli.md
+++ b/docs/simvar-cli.md
@@ -1,0 +1,349 @@
+---
+title: "SimVar CLI"
+description: "Interactive CLI tool for reading, writing, and streaming MSFS SimVars from the command line"
+section: "examples"
+order: 1
+---
+
+# SimVar CLI
+
+`simvar-cli` is a standalone Windows command-line tool for reading, writing, and streaming MSFS Simulation Variables (SimVars) directly from a terminal. It connects to a running simulator via SimConnect, executes the requested operation, and exits — or streams continuously until you press Ctrl+C.
+
+The tool lives in `examples/simvar-cli/` and has its own `go.mod`. It cannot be built from the repository root.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `get` | Read one SimVar value and print it |
+| `set` | Write a value to a SimVar |
+| `emit` | Fire a client event with optional data |
+| `listen` | Monitor client events in real time |
+| `repl` | Interactive session (default when no command is given) |
+| `watch` | Stream a SimVar continuously at a chosen interval |
+
+## Installation / Build
+
+```bash
+cd examples/simvar-cli
+go build -o simvar-cli.exe .
+```
+
+**Prerequisites:**
+
+- Windows OS — SimConnect is Windows-only
+- Microsoft Flight Simulator 2020 or 2024 running
+- SimConnect SDK installed (SimConnect.dll accessible)
+- Go 1.25+
+
+The `go.mod` includes a `replace` directive pointing to the parent module (`../..`) for local development.
+
+## Global Flags
+
+These flags are accepted before the subcommand name and apply to all commands.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dll-path <path>` | `""` | Explicit path to SimConnect.dll |
+| `--auto-detect` | `false` | Auto-detect SimConnect.dll location |
+| `--log-level <level>` | `warn` | Log level: `debug`, `info`, `warn`, `error` |
+| `--timeout <seconds>` | `10` | Operation timeout in seconds |
+| `--format <format>` | `table` | Output format: `table`, `json`, or `csv` |
+| `--config <path>` | `""` | Path to a TOML config file |
+
+Flag precedence (highest to lowest): CLI flag > config file value > built-in default. The tool uses `flag.Visit` to detect which flags were explicitly set on the command line, so config values are only applied for flags you did not provide.
+
+## Commands
+
+### get
+
+Read one SimVar value and print it to stdout.
+
+```
+simvar-cli [global flags] get <variable-name> <unit> <datatype>
+```
+
+```bash
+simvar-cli get "PLANE ALTITUDE" feet float64
+simvar-cli get "AIRSPEED INDICATED" knots float64
+simvar-cli get "CAMERA STATE" "" int32
+```
+
+The raw value is printed to stdout. Connection status and errors go to stderr, so the value is safe to pipe or redirect.
+
+### set
+
+Write a value to a SimVar on the user aircraft.
+
+```
+simvar-cli [global flags] set <variable-name> <unit> <datatype> <value>
+```
+
+```bash
+simvar-cli set "AUTOPILOT HEADING LOCK DIR" degrees float64 270.0
+simvar-cli set "CAMERA STATE" "" int32 3
+```
+
+Prints `OK` on success or a SimConnect exception description on failure.
+
+### emit
+
+Fire a client event. Accepts 0–5 integer data values. Uses `TransmitClientEvent` for 0–1 values and `TransmitClientEventEx1` for 2–5 values. Data values are parsed as int32 and cast to uint32, so negative values are accepted.
+
+```
+simvar-cli [global flags] emit <event-name> [data...]
+```
+
+```bash
+simvar-cli emit AP_MASTER
+simvar-cli emit TOGGLE_AIRCRAFT_EXIT 3
+simvar-cli emit AXIS_ELEVATOR_SET -8000
+simvar-cli emit SOME_EVENT 1 2 3 4 5
+```
+
+### listen
+
+Monitor client events in real time. Prints each received event as `[RFC3339 timestamp] EVENT_NAME data=VALUE` until interrupted with Ctrl+C.
+
+```
+simvar-cli [global flags] listen <event-name> [event-name...]
+```
+
+```bash
+simvar-cli listen GEAR_TOGGLE
+simvar-cli listen AP_MASTER GEAR_TOGGLE
+```
+
+### repl
+
+Start an interactive session with a persistent simulator connection. This is the default when no subcommand is given. The REPL is significantly faster for multiple operations because it avoids the connection overhead of individual commands.
+
+```
+simvar-cli [global flags] repl
+simvar-cli                       # implicit REPL
+```
+
+Inside the REPL, the following commands are available:
+
+| Command | Description |
+|---------|-------------|
+| `get <var> <unit> <datatype>` | Read a SimVar value |
+| `set <var> <unit> <datatype> <value>` | Write a SimVar value |
+| `emit <event-name> [data...]` | Fire a client event |
+| `listen <event-name> [event-name...]` | Subscribe to events |
+| `unlisten <event-name>` | Unsubscribe from an event |
+| `listeners` | Show active event listeners |
+| `help` | Show available commands |
+| `exit` / `quit` | End the session |
+
+### watch
+
+Stream a SimVar continuously, printing one reading per update until interrupted with Ctrl+C. The `--format` global flag controls the output format — useful for piping into `jq` or redirecting to a CSV file.
+
+```
+simvar-cli [global flags] watch [--interval second|visual-frame|sim-frame] [--changed] <variable-name> <unit> <datatype>
+```
+
+See [watch command](#watch-command) for full details.
+
+## watch command
+
+The `watch` command subscribes to a SimVar using `RequestDataOnSimObject` and streams readings until SIGINT. It accepts two command-specific flags in addition to all global flags.
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--interval` | `second` | Polling period: `second`, `visual-frame`, or `sim-frame` |
+| `--changed` | `false` | Only output a reading when the value differs from the previous one |
+
+### Interval Values
+
+| Value | SimConnect constant | When a reading is sent |
+|-------|---------------------|------------------------|
+| `second` | `SIMCONNECT_PERIOD_SECOND` | Once per simulated second |
+| `visual-frame` | `SIMCONNECT_PERIOD_VISUAL_FRAME` | Once per rendered frame |
+| `sim-frame` | `SIMCONNECT_PERIOD_SIM_FRAME` | Once per simulation tick |
+
+`sim-frame` produces the highest frequency. Use `--changed` with `sim-frame` or `visual-frame` to suppress noise when the variable is stable.
+
+### --changed behaviour
+
+When `--changed` is set, the tool compares each incoming value string against the previous one and skips the write step if they are equal. The comparison is string-level (post-formatting), so it reflects the value as it would appear in output.
+
+### Examples
+
+```bash
+# Stream altitude once per second in the default table format
+simvar-cli watch "PLANE ALTITUDE" feet float64
+
+# Stream latitude at visual frame rate
+simvar-cli watch --interval visual-frame "PLANE LATITUDE" degrees float64
+
+# Stream autopilot state only when it changes
+simvar-cli watch --interval sim-frame --changed "AUTOPILOT MASTER" "" int32
+
+# Pipe altitude readings as NDJSON into jq
+simvar-cli --format json watch "PLANE ALTITUDE" feet float64 | jq -r '.value'
+
+# Record altitude to CSV
+simvar-cli --format csv watch "PLANE ALTITUDE" feet float64 > altitude.csv
+```
+
+Press Ctrl+C to stop. The data definition and simulator connection are cleaned up before exit.
+
+## Output Formats
+
+The `--format` global flag applies to the `get` and `watch` commands. Each reading is one `FormattedValue` struct rendered according to the chosen format.
+
+### table (default)
+
+Four labelled lines per reading. The label column is 9 characters wide for alignment.
+
+```
+Name:     PLANE ALTITUDE
+Value:    35024.5 feet
+DataType: float64
+Time:     2025-11-01T12:34:56.789123456Z
+```
+
+### json
+
+One JSON object per reading followed by a newline — valid NDJSON. Each object carries the fields `name`, `value`, `unit`, `datatype`, and `timestamp` (RFC 3339 with nanoseconds).
+
+```json
+{"name":"PLANE ALTITUDE","value":"35024.5","unit":"feet","datatype":"float64","timestamp":"2025-11-01T12:34:56.789123456Z"}
+```
+
+Multiple readings produce one object per line, suitable for processing with `jq`:
+
+```bash
+simvar-cli --format json watch "PLANE ALTITUDE" feet float64 | jq '.value'
+```
+
+### csv
+
+RFC 4180 CSV output. The header row is written once at stream start by `FormatCSVHeader`. Each subsequent reading is one data row. Field order matches the JSON keys: `name`, `value`, `unit`, `datatype`, `timestamp`.
+
+```
+name,value,unit,datatype,timestamp
+PLANE ALTITUDE,35024.5,feet,float64,2025-11-01T12:34:56.789123456Z
+PLANE ALTITUDE,35100.2,feet,float64,2025-11-01T12:34:57.001234567Z
+```
+
+Redirect to a file for post-processing:
+
+```bash
+simvar-cli --format csv watch "PLANE ALTITUDE" feet float64 > altitude.csv
+```
+
+## Config File
+
+`simvar-cli` supports a TOML configuration file for setting persistent defaults without repeating flags on every invocation.
+
+### Resolution Order
+
+The tool searches for a config file in this order. The first file found is decoded; later candidates are not checked.
+
+1. `--config <path>` — explicit path provided on the command line; the file must exist or the tool exits with an error
+2. `SIMVAR_CLI_CONFIG` environment variable — explicit path; the file must exist or the tool exits with an error
+3. `%APPDATA%\simvar-cli\config.toml` — user-level default location; silently ignored if absent
+4. `.\simvar-cli.toml` in the current working directory — project-level default; silently ignored if absent
+
+If no file is found at any candidate, the tool starts with built-in defaults and no error is reported.
+
+### Config Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `dll_path` | string | `""` | Explicit path to SimConnect.dll |
+| `auto_detect` | bool | `false` | Auto-detect SimConnect.dll location |
+| `timeout` | int | `10` | Operation timeout in seconds |
+| `log_level` | string | `"warn"` | Log level: `debug`, `info`, `warn`, `error` |
+| `format` | string | `"table"` | Output format: `table`, `json`, `csv` |
+
+### Example Config File
+
+```toml
+# simvar-cli.toml
+
+dll_path    = "C:\\MSFS SDK\\SimConnect SDK\\lib\\SimConnect.dll"
+auto_detect = false
+timeout     = 30
+log_level   = "warn"
+format      = "table"
+```
+
+Save as `%APPDATA%\simvar-cli\config.toml` for a user-level default that applies everywhere, or as `simvar-cli.toml` in a project directory for per-project defaults.
+
+> **Note:** CLI flags always override config file values. A flag you explicitly pass on the command line will never be overwritten by the config.
+
+## Examples
+
+### Read altitude and pipe to another tool
+
+```bash
+simvar-cli get "PLANE ALTITUDE" feet float64
+# 35024.5
+```
+
+### Set autopilot heading
+
+```bash
+simvar-cli set "AUTOPILOT HEADING LOCK DIR" degrees float64 090.0
+# OK
+```
+
+### Toggle gear and verify
+
+```bash
+simvar-cli emit GEAR_TOGGLE
+simvar-cli get "GEAR TOTAL PCT EXTENDED" "" float64
+```
+
+### Stream altitude as NDJSON and extract values with jq
+
+```bash
+simvar-cli --format json watch "PLANE ALTITUDE" feet float64 | jq -r '.value'
+```
+
+### Record a flight data trace to CSV
+
+```bash
+simvar-cli --format csv watch "PLANE ALTITUDE" feet float64 > trace.csv
+```
+
+### Use a project config file
+
+```bash
+# Create simvar-cli.toml in the working directory
+echo 'dll_path = "C:\\SDK\\SimConnect.dll"' > simvar-cli.toml
+echo 'format   = "json"'                  >> simvar-cli.toml
+
+# All subsequent runs use these defaults
+simvar-cli watch "PLANE ALTITUDE" feet float64
+```
+
+### Override config with CLI flags
+
+```bash
+# Config sets format = "json", but this run uses CSV instead
+simvar-cli --format csv watch "PLANE ALTITUDE" feet float64
+```
+
+## Supported Data Types
+
+| Type | Size | Go Type | Example Values |
+|------|------|---------|----------------|
+| `int32` | 4 bytes | `int32` | `0`, `3`, `-1` |
+| `int64` | 8 bytes | `int64` | `0`, `100000` |
+| `float32` | 4 bytes | `float32` | `3.14`, `0.0` |
+| `float64` | 8 bytes | `float64` | `35024.5`, `245.3` |
+
+Most positional and rate SimVars use `float64`. State and enum SimVars typically use `int32`.
+
+## See Also
+
+- [MSFS 2024 Simulation Variables reference](https://docs.flightsimulator.com/msfs2024/html/6_Programming_APIs/SimVars/Simulation_Variables.htm)
+- [Engine/Client Usage](usage-client.md)
+- [Manager Usage](usage-manager.md)

--- a/examples/simvar-cli/README.md
+++ b/examples/simvar-cli/README.md
@@ -11,8 +11,9 @@ Interactive command-line tool for reading and writing MSFS Simulation Variables 
 3. **Emit Events** - Fires client events (e.g., AP_MASTER, GEAR_TOGGLE) with optional data parameters
 4. **Listen for Events** - Monitors client events in real time with timestamps until Ctrl+C
 5. **Interactive REPL** - Opens a persistent session for issuing multiple get/set/emit/listen commands without reconnecting
-6. **Auto-reconnection** - Retries connection to the simulator with 2-second intervals until successful
-7. **Graceful shutdown** - Responds to Ctrl+C interrupt signals cleanly
+6. **Watch (stream)** - Streams a SimVar continuously at a chosen interval until Ctrl+C
+7. **Auto-reconnection** - Retries connection to the simulator with 2-second intervals until successful
+8. **Graceful shutdown** - Responds to Ctrl+C interrupt signals cleanly
 
 ## Prerequisites
 
@@ -49,6 +50,8 @@ All commands accept these flags before the subcommand:
 | `--auto-detect` | `false` | Auto-detect SimConnect.dll location |
 | `--log-level` | `warn` | Log level (`debug`, `info`, `warn`, `error`) |
 | `--timeout` | `10` | Timeout in seconds for operations |
+| `--format` | `table` | Output format: `table`, `json`, or `csv` |
+| `--config` | `""` | Path to a TOML config file |
 
 ### Get a SimVar
 
@@ -131,6 +134,47 @@ simvar-cli listen AP_MASTER GEAR_TOGGLE
 
 **Output:** Each received event is printed as `[RFC3339 timestamp] EVENT_NAME data=VALUE`. Connection status goes to stderr.
 
+### Watch (stream) a SimVar
+
+Stream a SimVar value continuously until interrupted with Ctrl+C. Useful for monitoring variables in real time or piping output into other tools.
+
+```bash
+# Syntax
+simvar-cli watch [--interval second|visual-frame|sim-frame] [--changed] <variable-name> <unit> <datatype>
+
+# Stream altitude once per second (default interval)
+simvar-cli watch "PLANE ALTITUDE" feet float64
+
+# Stream at visual frame rate
+simvar-cli watch --interval visual-frame "PLANE LATITUDE" degrees float64
+
+# Only print when value changes (suppresses duplicate readings)
+simvar-cli watch --interval sim-frame --changed "AUTOPILOT MASTER" "" int32
+
+# Stream altitude as NDJSON
+simvar-cli --format json watch "PLANE ALTITUDE" feet float64
+
+# Stream to CSV file
+simvar-cli --format csv watch "PLANE ALTITUDE" feet float64 > altitude.csv
+```
+
+**Flags:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--interval` | `second` | Polling period: `second`, `visual-frame`, or `sim-frame` |
+| `--changed` | `false` | Only output a reading when the value differs from the previous one |
+
+**Interval mapping:**
+
+| Value | SimConnect period | Notes |
+|-------|-------------------|-------|
+| `second` | `SIMCONNECT_PERIOD_SECOND` | One reading per simulated second |
+| `visual-frame` | `SIMCONNECT_PERIOD_VISUAL_FRAME` | One reading per rendered frame |
+| `sim-frame` | `SIMCONNECT_PERIOD_SIM_FRAME` | One reading per simulation tick |
+
+Press Ctrl+C to stop streaming. The connection is closed cleanly on exit.
+
 ### REPL Mode
 
 Start an interactive session. This is the default when no subcommand is given.
@@ -189,6 +233,94 @@ REPL commands:
 
 The REPL maintains a single persistent connection and handles responses asynchronously, so it is significantly faster for multiple operations than running individual `get`/`set`/`emit` commands. Event listeners print incoming events to stderr to keep the prompt clean.
 
+## Output Formats
+
+The `--format` global flag controls how readings are rendered. It applies to the `get` and `watch` commands.
+
+| Format | Description |
+|--------|-------------|
+| `table` | Human-readable, four labelled lines per reading (default) |
+| `json` | One JSON object per reading, newline-delimited (NDJSON) |
+| `csv` | RFC 4180 CSV: one header row followed by one data row per reading |
+
+### table (default)
+
+```
+Name:     PLANE ALTITUDE
+Value:    35024.5 feet
+DataType: float64
+Time:     2025-11-01T12:34:56.789Z
+```
+
+### json
+
+Each reading is a complete JSON object followed by a newline. Multiple readings produce valid NDJSON that can be processed with `jq`.
+
+```json
+{"name":"PLANE ALTITUDE","value":"35024.5","unit":"feet","datatype":"float64","timestamp":"2025-11-01T12:34:56.789123456Z"}
+```
+
+```bash
+simvar-cli --format json watch "PLANE ALTITUDE" feet float64 | jq '.value'
+```
+
+### csv
+
+The first line is always a header row written by `FormatCSVHeader`. Each subsequent reading is a data row. Field order: `name,value,unit,datatype,timestamp`.
+
+```
+name,value,unit,datatype,timestamp
+PLANE ALTITUDE,35024.5,feet,float64,2025-11-01T12:34:56.789123456Z
+PLANE ALTITUDE,35100.2,feet,float64,2025-11-01T12:34:57.001234567Z
+```
+
+```bash
+simvar-cli --format csv watch "PLANE ALTITUDE" feet float64 > altitude.csv
+```
+
+## Config File
+
+`simvar-cli` supports a TOML configuration file for setting defaults without repeating flags on every invocation.
+
+### Resolution Order
+
+The config file is resolved in this order. The first file found is used; later candidates are not checked.
+
+1. `--config <path>` flag — explicit path; file must exist or the tool exits with an error
+2. `SIMVAR_CLI_CONFIG` environment variable — explicit path; file must exist or the tool exits with an error
+3. `%APPDATA%\simvar-cli\config.toml` — user-level default; silently ignored if absent
+4. `.\simvar-cli.toml` in the current working directory — project-level default; silently ignored if absent
+
+If no config file is found, the tool uses its built-in defaults.
+
+### Config Fields
+
+| Field | Type | Description | Default |
+|-------|------|-------------|---------|
+| `dll_path` | string | Explicit path to SimConnect.dll | `""` |
+| `auto_detect` | bool | Auto-detect SimConnect.dll location | `false` |
+| `timeout` | int | Timeout in seconds for operations | `10` |
+| `log_level` | string | Log level: `debug`, `info`, `warn`, `error` | `"warn"` |
+| `format` | string | Output format: `table`, `json`, `csv` | `"table"` |
+
+### Precedence
+
+CLI flags always win over config file values, which win over built-in defaults. The tool uses `flag.Visit` to detect which flags were explicitly provided; unset flags fall back to the config, then to defaults.
+
+### Example Config File
+
+```toml
+# simvar-cli.toml
+
+dll_path    = "C:\\MSFS SDK\\SimConnect SDK\\lib\\SimConnect.dll"
+auto_detect = false
+timeout     = 30
+log_level   = "warn"
+format      = "table"
+```
+
+Save as `%APPDATA%\simvar-cli\config.toml` for user-level defaults, or as `simvar-cli.toml` in the directory you run the tool from for project-level defaults.
+
 ## Supported Data Types
 
 | Type | Size | Go Type | Example Values |
@@ -218,14 +350,16 @@ For unitless variables (e.g., `CAMERA STATE`), pass an empty string `""` as the 
 
 | File | Purpose |
 |------|---------|
-| `main.go` | Entrypoint, global flag parsing, CURE router setup |
-| `bridge.go` | Shared utilities: ID counters, type parsing, value formatting, event mapping |
+| `main.go` | Entrypoint, global flag parsing, config loading, CURE router setup |
+| `bridge.go` | Shared utilities: ID counters, type parsing, value formatting, event mapping, output formatting |
+| `config.go` | TOML config file loading with 4-step resolution |
 | `get.go` | `get` command implementation |
 | `set.go` | `set` command implementation |
 | `emit.go` | `emit` command implementation (TransmitClientEvent / TransmitClientEventEx1) |
 | `listen.go` | `listen` command implementation (notification group based event monitoring) |
 | `repl.go` | `repl` command with interactive input loop, async response handling, and event commands |
-| `go.mod` | Standalone module with CURE dependency and parent module replace directive |
+| `watch.go` | `watch` command — continuous streaming with interval and changed-only filtering |
+| `go.mod` | Standalone module with CURE and BurntSushi/toml dependencies and parent module replace directive |
 
 ## SimVar Reference
 
@@ -235,8 +369,8 @@ For the full list of available simulation variables, units, and data types, see 
 
 ## Notes
 
-- The tool connects as client name `SimVar CLI - Get`, `SimVar CLI - Set`, `SimVar CLI - Emit`, `SimVar CLI - Listen`, or `SimVar CLI - REPL` depending on the command
-- Each `get`, `set`, `emit`, and `listen` invocation creates a fresh connection; use REPL mode for repeated operations
+- The tool connects as client name `SimVar CLI - Get`, `SimVar CLI - Set`, `SimVar CLI - Emit`, `SimVar CLI - Listen`, `SimVar CLI - REPL`, or `SimVar CLI - Watch` depending on the command
+- Each `get`, `set`, `emit`, `listen`, and `watch` invocation creates a fresh connection; use REPL mode for repeated operations
 - Event mappings (MapClientEventToSimEvent) are cached and reused across multiple emit/listen calls within a session
 - The `go.mod` uses a `replace` directive pointing to the parent module (`../..`) for local development
 - `unsafe.Pointer` is used internally for `SetDataOnSimObject` calls, matching the pattern in the `set-variables` example

--- a/examples/simvar-cli/bridge.go
+++ b/examples/simvar-cli/bridge.go
@@ -4,11 +4,15 @@
 package main
 
 import (
+	"encoding/csv"
+	"encoding/json"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/mrlm-net/simconnect/pkg/engine"
 	"github.com/mrlm-net/simconnect/pkg/types"
@@ -180,4 +184,117 @@ func formatValue(dwData *types.DWORD, dt types.SIMCONNECT_DATATYPE) string {
 	default:
 		return "<unsupported type>"
 	}
+}
+
+// ── Output formatting ────────────────────────────────────────────────────────
+
+// OutputFormat selects the rendering style for FormatOutput.
+// String alias chosen over iota: format values originate as strings from
+// CLI flags and TOML config files — no parse indirection required.
+type OutputFormat string
+
+const (
+	FormatTable OutputFormat = "table"
+	FormatJSON  OutputFormat = "json"
+	FormatCSV   OutputFormat = "csv"
+)
+
+// parseOutputFormat validates and normalises a raw string into an OutputFormat.
+// Accepts "table", "json", "csv" (case-insensitive).
+// Returns FormatTable and an error for any unrecognised value.
+func parseOutputFormat(s string) (OutputFormat, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "table":
+		return FormatTable, nil
+	case "json":
+		return FormatJSON, nil
+	case "csv":
+		return FormatCSV, nil
+	default:
+		return FormatTable, fmt.Errorf("unknown output format %q: must be table, json, or csv", s)
+	}
+}
+
+// FormattedValue is the data transfer object for FormatOutput.
+// It carries one SimVar reading with all context needed to render in any format.
+type FormattedValue struct {
+	Name      string    // SimVar name as supplied by the caller
+	Value     string    // Pre-formatted value string (from formatValue)
+	Unit      string    // Unit string as supplied by the caller
+	DataType  string    // Datatype label ("int32", "float64", etc.)
+	Timestamp time.Time // Time of value receipt
+}
+
+// FormatOutput renders fv to w in the requested format.
+//
+// table: four labelled lines — Name, Value, DataType, Time — with a
+//
+//	fixed 9-character label column for alignment.
+//
+// json:  single JSON object with RFC3339Nano timestamp, followed by a newline.
+//
+//	Each call writes exactly one complete, parseable JSON object (NDJSON).
+//
+// csv:   single data row (no header). Call FormatCSVHeader once before the
+//
+//	first FormatOutput(csv) call to write the header row.
+//
+// Returns a non-nil error for an unknown format or any write failure.
+func FormatOutput(w io.Writer, fv FormattedValue, format OutputFormat) error {
+	switch format {
+	case FormatTable:
+		_, err := fmt.Fprintf(w, "%-9s %s\n%-9s %s %s\n%-9s %s\n%-9s %s\n",
+			"Name:", fv.Name,
+			"Value:", fv.Value, fv.Unit,
+			"DataType:", fv.DataType,
+			"Time:", fv.Timestamp.Format(time.RFC3339Nano),
+		)
+		return err
+	case FormatJSON:
+		obj := struct {
+			Name      string `json:"name"`
+			Value     string `json:"value"`
+			Unit      string `json:"unit"`
+			DataType  string `json:"datatype"`
+			Timestamp string `json:"timestamp"`
+		}{
+			Name:      fv.Name,
+			Value:     fv.Value,
+			Unit:      fv.Unit,
+			DataType:  fv.DataType,
+			Timestamp: fv.Timestamp.Format(time.RFC3339Nano),
+		}
+		b, err := json.Marshal(obj)
+		if err != nil {
+			return fmt.Errorf("FormatOutput json: %w", err)
+		}
+		_, err = fmt.Fprintf(w, "%s\n", b)
+		return err
+	case FormatCSV:
+		cw := csv.NewWriter(w)
+		if err := cw.Write([]string{
+			fv.Name,
+			fv.Value,
+			fv.Unit,
+			fv.DataType,
+			fv.Timestamp.Format(time.RFC3339Nano),
+		}); err != nil {
+			return fmt.Errorf("FormatOutput csv: %w", err)
+		}
+		cw.Flush()
+		return cw.Error()
+	default:
+		return fmt.Errorf("FormatOutput: unknown format %q", format)
+	}
+}
+
+// FormatCSVHeader writes the CSV header row to w.
+// Call this exactly once before the first FormatOutput(FormatCSV, ...) call.
+func FormatCSVHeader(w io.Writer) error {
+	cw := csv.NewWriter(w)
+	if err := cw.Write([]string{"name", "value", "unit", "datatype", "timestamp"}); err != nil {
+		return fmt.Errorf("FormatCSVHeader: %w", err)
+	}
+	cw.Flush()
+	return cw.Error()
 }

--- a/examples/simvar-cli/config.go
+++ b/examples/simvar-cli/config.go
@@ -1,0 +1,69 @@
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Config holds values loaded from the TOML config file.
+// Zero values mean "not set by config" — caller applies its own defaults.
+type Config struct {
+	DLLPath    string `toml:"dll_path"`
+	AutoDetect bool   `toml:"auto_detect"`
+	Timeout    int    `toml:"timeout"`
+	LogLevel   string `toml:"log_level"`
+	Format     string `toml:"format"`
+}
+
+// loadConfig resolves the config file using the lookup order below,
+// decodes the TOML, and returns the populated Config.
+//
+// Lookup order (first found and readable wins):
+//  1. explicit — the --config flag value (non-empty); missing = error
+//  2. SIMVAR_CLI_CONFIG env var; missing file = error
+//  3. %APPDATA%\simvar-cli\config.toml; missing = silently ignored
+//  4. .\simvar-cli.toml in working dir; missing = silently ignored
+//
+// If no candidate file exists, returns zero Config and nil error.
+func loadConfig(explicit string) (Config, error) {
+	type candidate struct {
+		path      string
+		mustExist bool
+	}
+
+	var candidates []candidate
+
+	if explicit != "" {
+		candidates = append(candidates, candidate{explicit, true})
+	} else {
+		if env := os.Getenv("SIMVAR_CLI_CONFIG"); env != "" {
+			candidates = append(candidates, candidate{env, true})
+		}
+		if appdata := os.Getenv("APPDATA"); appdata != "" {
+			candidates = append(candidates, candidate{filepath.Join(appdata, "simvar-cli", "config.toml"), false})
+		}
+		candidates = append(candidates, candidate{"simvar-cli.toml", false})
+	}
+
+	for _, c := range candidates {
+		_, err := os.Stat(c.path)
+		if err != nil {
+			if c.mustExist {
+				return Config{}, fmt.Errorf("config: file not found: %q", c.path)
+			}
+			continue
+		}
+		var cfg Config
+		if _, err := toml.DecodeFile(c.path, &cfg); err != nil {
+			return Config{}, fmt.Errorf("config: decode %q: %w", c.path, err)
+		}
+		return cfg, nil
+	}
+	return Config{}, nil
+}

--- a/examples/simvar-cli/go.mod
+++ b/examples/simvar-cli/go.mod
@@ -7,4 +7,6 @@ require (
 	github.com/mrlm-net/simconnect v0.0.0
 )
 
+require github.com/BurntSushi/toml v1.6.0 // indirect
+
 replace github.com/mrlm-net/simconnect => ../..

--- a/examples/simvar-cli/go.mod
+++ b/examples/simvar-cli/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/mrlm-net/simconnect v0.0.0
 )
 
-require github.com/BurntSushi/toml v1.6.0 // indirect
+require github.com/BurntSushi/toml v1.6.0
 
 replace github.com/mrlm-net/simconnect => ../..

--- a/examples/simvar-cli/go.sum
+++ b/examples/simvar-cli/go.sum
@@ -1,2 +1,4 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/mrlm-net/cure v0.4.0 h1:gd7JAfwITZjqDzjmkb690CQHmX8BZdWe7Pb5rQGgalE=
 github.com/mrlm-net/cure v0.4.0/go.mod h1:61m63SMXSTdxRI1tuuPJgEDi/UpMDUOHAjxEOnpRjds=

--- a/examples/simvar-cli/main.go
+++ b/examples/simvar-cli/main.go
@@ -21,13 +21,18 @@ func main() {
 		autoDetect bool
 		logLevel   string
 		timeout    int
+		format     string
+		configPath string
 	)
 
 	fs := flag.NewFlagSet("simvar-cli", flag.ContinueOnError)
 	fs.StringVar(&dllPath, "dll-path", "", "Path to SimConnect.dll")
 	fs.BoolVar(&autoDetect, "auto-detect", false, "Auto-detect SimConnect.dll location")
-	fs.StringVar(&logLevel, "log-level", "warn", "Log level (debug, info, warn, error)")
-	fs.IntVar(&timeout, "timeout", 10, "Timeout in seconds for operations")
+	// Defaults intentionally empty — handled by config + hard-default block below
+	fs.StringVar(&logLevel, "log-level", "", "Log level (debug, info, warn, error)")
+	fs.IntVar(&timeout, "timeout", 0, "Timeout in seconds for operations")
+	fs.StringVar(&format, "format", "", "Output format: table, json, csv (default: table)")
+	fs.StringVar(&configPath, "config", "", "Path to config file (TOML)")
 
 	// Find the subcommand position (first non-flag argument)
 	args := os.Args[1:]
@@ -37,7 +42,53 @@ func main() {
 	}
 	remaining := fs.Args()
 
-	// Build engine options from global flags
+	// Load config file
+	cfg, err := loadConfig(configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Apply config values for flags not explicitly set by the user.
+	// flag.Visit iterates only flags the user explicitly provided.
+	userSet := make(map[string]bool)
+	fs.Visit(func(f *flag.Flag) { userSet[f.Name] = true })
+
+	if !userSet["dll-path"] && cfg.DLLPath != "" {
+		dllPath = cfg.DLLPath
+	}
+	if !userSet["auto-detect"] && cfg.AutoDetect {
+		autoDetect = cfg.AutoDetect
+	}
+	if !userSet["log-level"] && cfg.LogLevel != "" {
+		logLevel = cfg.LogLevel
+	}
+	if !userSet["timeout"] && cfg.Timeout != 0 {
+		timeout = cfg.Timeout
+	}
+	if !userSet["format"] && cfg.Format != "" {
+		format = cfg.Format
+	}
+
+	// Apply hard defaults for anything still unset
+	if logLevel == "" {
+		logLevel = "warn"
+	}
+	if timeout == 0 {
+		timeout = 10
+	}
+	if format == "" {
+		format = string(FormatTable)
+	}
+
+	// Validate format before connecting to simulator
+	outputFormat, err := parseOutputFormat(format)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Build engine options from resolved global flags
 	var engineOpts []engine.Option
 	if dllPath != "" {
 		engineOpts = append(engineOpts, engine.WithDLLPath(dllPath))
@@ -62,6 +113,7 @@ func main() {
 	router.Register(&emitCommand{engineOpts: engineOpts, timeout: timeout})
 	router.Register(&listenCommand{engineOpts: engineOpts, timeout: timeout})
 	router.Register(&replCommand{engineOpts: engineOpts, timeout: timeout})
+	router.Register(&watchCommand{engineOpts: engineOpts, timeout: timeout, format: outputFormat})
 
 	// Setup signal handler context
 	ctx, cancel := context.WithCancel(context.Background())

--- a/examples/simvar-cli/watch.go
+++ b/examples/simvar-cli/watch.go
@@ -1,0 +1,181 @@
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/mrlm-net/cure/pkg/terminal"
+	"github.com/mrlm-net/simconnect/pkg/engine"
+	"github.com/mrlm-net/simconnect/pkg/types"
+)
+
+type watchCommand struct {
+	engineOpts []engine.Option
+	timeout    int
+	format     OutputFormat
+}
+
+func (c *watchCommand) Name() string        { return "watch" }
+func (c *watchCommand) Description() string { return "Stream a SimVar value continuously from the simulator" }
+func (c *watchCommand) Usage() string {
+	return "watch [--interval second|visual-frame|sim-frame] [--changed] <variable-name> <unit> <datatype>\n\n" +
+		"Examples:\n" +
+		"  watch \"PLANE ALTITUDE\" feet float64\n" +
+		"  watch --interval visual-frame \"PLANE LATITUDE\" degrees float64\n" +
+		"  watch --interval sim-frame --changed \"AUTOPILOT MASTER\" \"\" int32"
+}
+
+func (c *watchCommand) Flags() *flag.FlagSet {
+	fs := flag.NewFlagSet("watch", flag.ContinueOnError)
+	fs.String("interval", "second", "Polling period: second, visual-frame, sim-frame")
+	fs.Bool("changed", false, "Only output when value changes from previous reading")
+	return fs
+}
+
+func (c *watchCommand) Run(ctx context.Context, tc *terminal.Context) error {
+	// Parse local flags from tc.Args (CURE pre-parses and strips them; tc.Args = positional args only).
+	// Re-parse here to access flag values.
+	fs := flag.NewFlagSet("watch", flag.ContinueOnError)
+	interval := fs.String("interval", "second", "")
+	changed := fs.Bool("changed", false, "")
+	if err := fs.Parse(tc.Args); err != nil {
+		return err
+	}
+	positional := fs.Args()
+	if len(positional) < 3 {
+		return fmt.Errorf("usage: %s", c.Usage())
+	}
+
+	varName := positional[0]
+	unit := positional[1]
+	dtStr := positional[2]
+
+	dt, err := parseDataType(dtStr)
+	if err != nil {
+		return err
+	}
+
+	period, err := parsePeriod(*interval)
+	if err != nil {
+		return err
+	}
+
+	// Connect with retry loop (same pattern as get.go)
+	opts := append([]engine.Option{engine.WithContext(ctx)}, c.engineOpts...)
+	client := engine.New("SimVar CLI - Watch", opts...)
+
+	fmt.Fprintf(tc.Stderr, "Connecting to simulator...\n")
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			if err := client.Connect(); err != nil {
+				fmt.Fprintf(tc.Stderr, "Connection failed: %v, retrying in 2s...\n", err)
+				time.Sleep(2 * time.Second)
+				continue
+			}
+			goto connected
+		}
+	}
+
+connected:
+	defer client.Disconnect()
+
+	defID := nextDefID()
+	reqID := nextReqID()
+
+	if err := client.AddToDataDefinition(defID, varName, unit, dt, 0, 0); err != nil {
+		return fmt.Errorf("AddToDataDefinition failed: %w", err)
+	}
+	defer client.ClearDataDefinition(defID)
+
+	if err := client.RequestDataOnSimObject(
+		reqID, defID,
+		types.SIMCONNECT_OBJECT_ID_USER,
+		period,
+		types.SIMCONNECT_DATA_REQUEST_FLAG_DEFAULT,
+		0, 0, 0,
+	); err != nil {
+		return fmt.Errorf("RequestDataOnSimObject failed: %w", err)
+	}
+
+	// Write CSV header once before streaming
+	if c.format == FormatCSV {
+		if err := FormatCSVHeader(tc.Stdout); err != nil {
+			return err
+		}
+	}
+
+	stream := client.Stream()
+	lastValue := ""
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case msg, ok := <-stream:
+			if !ok {
+				return fmt.Errorf("stream closed unexpectedly")
+			}
+			if msg.Err != nil {
+				msg.Release()
+				fmt.Fprintf(tc.Stderr, "Stream error: %v\n", msg.Err)
+				continue
+			}
+
+			switch types.SIMCONNECT_RECV_ID(msg.DwID) {
+			case types.SIMCONNECT_RECV_ID_SIMOBJECT_DATA:
+				data := msg.AsSimObjectData()
+				if data != nil && uint32(data.DwRequestID) == reqID {
+					raw := formatValue(&data.DwData, dt)
+					if *changed && raw == lastValue {
+						msg.Release()
+						continue
+					}
+					lastValue = raw
+					fv := FormattedValue{
+						Name:      varName,
+						Value:     raw,
+						Unit:      unit,
+						DataType:  dtStr,
+						Timestamp: time.Now(),
+					}
+					if err := FormatOutput(tc.Stdout, fv, c.format); err != nil {
+						msg.Release()
+						return fmt.Errorf("FormatOutput: %w", err)
+					}
+				}
+			case types.SIMCONNECT_RECV_ID_EXCEPTION:
+				exc := msg.AsException()
+				if exc != nil {
+					fmt.Fprintf(tc.Stderr, "SimConnect exception: ID=%d, SendID=%d, Index=%d\n",
+						exc.DwException, exc.DwSendID, exc.DwIndex)
+				}
+			case types.SIMCONNECT_RECV_ID_OPEN:
+				// Connection confirmed
+			}
+			msg.Release()
+		}
+	}
+}
+
+// parsePeriod maps a watch --interval string to the SimConnect period constant.
+func parsePeriod(s string) (types.SIMCONNECT_PERIOD, error) {
+	switch s {
+	case "second":
+		return types.SIMCONNECT_PERIOD_SECOND, nil
+	case "visual-frame":
+		return types.SIMCONNECT_PERIOD_VISUAL_FRAME, nil
+	case "sim-frame":
+		return types.SIMCONNECT_PERIOD_SIM_FRAME, nil
+	default:
+		return types.SIMCONNECT_PERIOD_NEVER,
+			fmt.Errorf("unknown interval %q: must be second, visual-frame, or sim-frame", s)
+	}
+}

--- a/website/src/lib/config/navigation.ts
+++ b/website/src/lib/config/navigation.ts
@@ -7,10 +7,11 @@ const sectionMeta: Record<string, { title: string; defaultOpen: boolean }> = {
 	traffic: { title: 'Traffic', defaultOpen: true },
 	events: { title: 'Events', defaultOpen: true },
 	packages: { title: 'Packages', defaultOpen: true },
+	examples: { title: 'Examples', defaultOpen: true },
 	internals: { title: 'Internals', defaultOpen: false }
 };
 
-const sectionOrder = ['client', 'manager', 'datasets', 'traffic', 'events', 'packages', 'internals'];
+const sectionOrder = ['client', 'manager', 'datasets', 'traffic', 'events', 'packages', 'examples', 'internals'];
 
 export function buildNavigation(docs: DocMeta[], basePath: string): NavSection[] {
 	const grouped = new Map<string, DocMeta[]>();


### PR DESCRIPTION
## Summary

- `config.go`: TOML config loading with 4-step resolution order (flag > env > APPDATA > local). Explicit missing path = error. BurntSushi/toml added to go.mod.
- `bridge.go`: OutputFormat string type, FormattedValue struct, FormatOutput (table/json/csv), FormatCSVHeader. Uses stdlib encoding/json + encoding/csv only.
- `main.go`: `--format table|json|csv` and `--config` global flags. flag.Visit-based CLI-over-config precedence. Format validated before simulator connection. watchCommand registered.
- `watch.go`: watch command streaming SimVar via FormatOutput until SIGINT. `--interval second|visual-frame|sim-frame` maps to SimConnect period enums. `--changed` suppresses unchanged output. defer-based cleanup.

## Test plan

- [ ] `go build .` passes in `examples/simvar-cli/`
- [ ] `go vet -unsafeptr=false .` passes
- [ ] `--format invalid` exits non-zero before connecting
- [ ] `--interval invalid` exits non-zero before connecting
- [ ] `--config /nonexistent/path.toml` exits with file-not-found error
- [ ] Missing implicit config files produce no error

Closes #162
Closes #163
Closes #164
Closes #165
Resolves #166
Part of #161