### PR TITLE
docs(manager): add client-data-area and input-events manager guides

### DIFF
--- a/docs/client-data-area.md
+++ b/docs/client-data-area.md
@@ -344,4 +344,5 @@ client.SetClientData(WeatherAreaID, WeatherDefID, 0, 0,
 
 - [Engine/Client Usage](usage-client.md) — Full client API reference including data definitions and sim object data
 - [Manager Usage](usage-manager.md) — Automatic connection lifecycle management
+- [Client Data Areas (Manager)](manager-client-data-area.md) — Using Client Data Areas through the manager with lifecycle-managed reconnection
 - [Examples](../examples) — Working code samples

--- a/docs/guide-input-events.md
+++ b/docs/guide-input-events.md
@@ -341,4 +341,5 @@ func main() {
 
 - [Engine/Client API Reference](usage-engine-api.md) — Full Input Event API section with the complete method reference table
 - [Engine/Client Usage](usage-client.md) — General dispatch loop patterns and message handling
+- [Input Events (Manager)](manager-input-events.md) — Using Input Events through the manager with lifecycle-managed reconnection and auto-reconnect considerations
 - [Client Configuration](config-client.md) — Connection options

--- a/docs/manager-client-data-area.md
+++ b/docs/manager-client-data-area.md
@@ -1,0 +1,326 @@
+---
+title: "Client Data Areas (Manager)"
+section: "manager"
+order: 6
+---
+
+# Client Data Areas (Manager)
+
+The `manager` package exposes the full SimConnect Client Data Area (CDA) API as direct methods on the `Manager` interface. This guide explains how to use CDAs through the manager's lifecycle-managed connection, covering both the reader and writer roles.
+
+> **See also:** [Client Data Areas](client-data-area.md) for the engine-layer reference covering types, constants, and low-level usage.
+
+## Overview
+
+Client data areas are named shared memory regions that SimConnect add-ons use to exchange arbitrary structured data. One add-on creates the area and writes to it; any other connected client can map the same name, define the layout, and subscribe to updates.
+
+Typical use cases:
+
+- A weather injector writes current conditions; a cockpit display reads and renders them.
+- A flight data recorder writes position and attitude; a telemetry exporter reads in real time.
+- Two independent add-ons share a control channel without a network connection.
+
+The manager wraps the same underlying SimConnect calls as the engine client. The key difference is that each method checks whether the manager is currently connected and returns `ErrNotConnected` if not. There is no automatic retry or queuing — callers are responsible for registering CDAs at the right time in the connection lifecycle.
+
+`MapClientDataNameToID` is also part of the manager interface and is the prerequisite for all CDA operations. Call it first after connection before calling any other CDA method.
+
+## Prerequisites
+
+Before calling any CDA method:
+
+1. The manager must be connected to the simulator. Use `OnConnectionStateChange` or `SubscribeOnOpen` to detect when the connection is ready.
+2. Choose define IDs and request IDs in the user range. See [Request and ID Management](manager-requests-ids.md) for the ID ranges. All user IDs must be between 1 and 999,999,849.
+3. The `requestID` passed to `RequestClientData` identifies responses in the dispatch loop. It must be unique within your application and within the user range.
+
+## Workflow
+
+The following steps apply to any CDA integration through the manager.
+
+### Step 1 — Map the area name to an ID
+
+Both the writer and the reader call `MapClientDataNameToID` with the same name string. This is what links the two clients together.
+
+```go
+const (
+    WeatherAreaID uint32 = 1000
+    WeatherDefID  uint32 = 1001
+    WeatherReqID  uint32 = 1002
+)
+
+mgr.OnConnectionStateChange(func(old, new manager.ConnectionState) {
+    if new != manager.StateConnected {
+        return
+    }
+    if err := mgr.MapClientDataNameToID("MyAddon.Weather", WeatherAreaID); err != nil {
+        log.Printf("MapClientDataNameToID failed: %v", err)
+    }
+})
+```
+
+### Step 2 — Create the area (writer only)
+
+The client that owns the area calls `CreateClientData`. Readers skip this step.
+
+```go
+// dwSize must be between 1 and 8192 bytes
+if err := mgr.CreateClientData(WeatherAreaID, 16, types.SIMCONNECT_CREATE_CLIENT_DATA_FLAG_DEFAULT); err != nil {
+    log.Printf("CreateClientData failed: %v", err)
+}
+```
+
+### Step 3 — Define the struct layout
+
+Call `AddToClientDataDefinition` once per field to describe the memory layout. Each call maps a byte offset and size to a definition ID.
+
+```go
+// Field 1: float64 at offset 0 (8 bytes)
+mgr.AddToClientDataDefinition(
+    WeatherDefID,
+    0,                                               // byte offset
+    uint32(types.SIMCONNECT_CLIENTDATATYPE_FLOAT64), // typed size constant
+    0,                                               // epsilon
+    0,                                               // datum ID
+)
+// Field 2: float64 at offset 8 (8 bytes)
+mgr.AddToClientDataDefinition(
+    WeatherDefID,
+    8,
+    uint32(types.SIMCONNECT_CLIENTDATATYPE_FLOAT64),
+    0,
+    0,
+)
+```
+
+### Step 4 — Subscribe to updates (reader)
+
+Call `RequestClientData` to register a periodic delivery subscription. Responses arrive as `SIMCONNECT_RECV_ID_CLIENT_DATA` messages.
+
+```go
+if err := mgr.RequestClientData(
+    WeatherAreaID,
+    WeatherReqID,
+    WeatherDefID,
+    types.SIMCONNECT_CLIENT_DATA_PERIOD_ON_SET,         // deliver on each write
+    types.SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_DEFAULT,
+    0, 0, 0,
+); err != nil {
+    log.Printf("RequestClientData failed: %v", err)
+}
+```
+
+### Step 5 — Receive updates
+
+Use `Subscribe` or `SubscribeWithFilter` to receive `SIMCONNECT_RECV_ID_CLIENT_DATA` messages:
+
+```go
+sub := mgr.SubscribeWithFilter("weather-cda", 20, func(msg engine.Message) bool {
+    return types.SIMCONNECT_RECV_ID(msg.DwID) == types.SIMCONNECT_RECV_ID_CLIENT_DATA
+})
+defer sub.Unsubscribe()
+
+go func() {
+    for {
+        select {
+        case msg := <-sub.Messages():
+            cd := msg.AsClientData()
+            if cd == nil || cd.DwRequestID != WeatherReqID {
+                continue
+            }
+            weather := engine.CastDataAs[SharedWeather](&cd.DwData)
+            log.Printf("Temperature: %.1f°C  Pressure: %.2f hPa",
+                weather.TemperatureC, weather.PressureHPa)
+        case <-sub.Done():
+            return
+        }
+    }
+}()
+```
+
+### Step 6 — Write data (writer)
+
+The owning add-on calls `SetClientData` whenever the data changes:
+
+```go
+data := SharedWeather{TemperatureC: 15.5, PressureHPa: 1013.25}
+if err := mgr.SetClientData(
+    WeatherAreaID,
+    WeatherDefID,
+    0,                               // flags — always 0
+    0,                               // dwReserved — must be 0
+    uint32(unsafe.Sizeof(data)),
+    unsafe.Pointer(&data),
+); err != nil {
+    log.Printf("SetClientData failed: %v", err)
+}
+```
+
+### Step 7 — Clean up
+
+When a definition is no longer needed, call `ClearClientDataDefinition` to release it:
+
+```go
+if err := mgr.ClearClientDataDefinition(WeatherDefID); err != nil {
+    log.Printf("ClearClientDataDefinition failed: %v", err)
+}
+```
+
+> **Note:** There is no `DeleteClientData` call in the SimConnect SDK. The area itself is released automatically when the owning client disconnects from the simulator.
+
+## Complete Example
+
+The following snippet shows a reader that connects via manager, maps an existing shared area, defines a two-field layout, and prints every update.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "errors"
+    "log"
+    "os"
+    "os/signal"
+    "unsafe"
+
+    "github.com/mrlm-net/simconnect"
+    "github.com/mrlm-net/simconnect/pkg/engine"
+    "github.com/mrlm-net/simconnect/pkg/manager"
+    "github.com/mrlm-net/simconnect/pkg/types"
+)
+
+type SharedWeather struct {
+    TemperatureC float64 // offset 0, 8 bytes
+    PressureHPa  float64 // offset 8, 8 bytes
+}
+
+const (
+    WeatherAreaID uint32 = 1000
+    WeatherDefID  uint32 = 1001
+    WeatherReqID  uint32 = 1002
+)
+
+func main() {
+    mgr := simconnect.New("WeatherReader",
+        manager.WithAutoReconnect(true),
+    )
+
+    mgr.OnConnectionStateChange(func(old, new manager.ConnectionState) {
+        if new != manager.StateConnected {
+            return
+        }
+        setupCDA(mgr)
+    })
+
+    sub := mgr.SubscribeWithFilter("weather-cda", 20, func(msg engine.Message) bool {
+        return types.SIMCONNECT_RECV_ID(msg.DwID) == types.SIMCONNECT_RECV_ID_CLIENT_DATA
+    })
+    defer sub.Unsubscribe()
+
+    go func() {
+        for {
+            select {
+            case msg := <-sub.Messages():
+                cd := msg.AsClientData()
+                if cd == nil || cd.DwRequestID != WeatherReqID {
+                    continue
+                }
+                weather := engine.CastDataAs[SharedWeather](&cd.DwData)
+                log.Printf("Temperature: %.1f°C  Pressure: %.2f hPa",
+                    weather.TemperatureC, weather.PressureHPa)
+            case <-sub.Done():
+                return
+            }
+        }
+    }()
+
+    sigChan := make(chan os.Signal, 1)
+    signal.Notify(sigChan, os.Interrupt)
+    go func() {
+        <-sigChan
+        mgr.Stop()
+    }()
+
+    if err := mgr.Start(); err != nil {
+        log.Printf("Manager stopped: %v", err)
+    }
+}
+
+func setupCDA(mgr manager.Manager) {
+    if err := mgr.MapClientDataNameToID("MyAddon.Weather", WeatherAreaID); err != nil {
+        log.Printf("MapClientDataNameToID: %v", err)
+        return
+    }
+    // Reader skips CreateClientData — only the writer calls it.
+    if err := mgr.AddToClientDataDefinition(WeatherDefID, 0,
+        uint32(types.SIMCONNECT_CLIENTDATATYPE_FLOAT64), 0, 0); err != nil {
+        log.Printf("AddToClientDataDefinition [0]: %v", err)
+    }
+    if err := mgr.AddToClientDataDefinition(WeatherDefID, 8,
+        uint32(types.SIMCONNECT_CLIENTDATATYPE_FLOAT64), 0, 0); err != nil {
+        log.Printf("AddToClientDataDefinition [8]: %v", err)
+    }
+    if err := mgr.RequestClientData(
+        WeatherAreaID, WeatherReqID, WeatherDefID,
+        types.SIMCONNECT_CLIENT_DATA_PERIOD_ON_SET,
+        types.SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_DEFAULT,
+        0, 0, 0,
+    ); err != nil {
+        if errors.Is(err, manager.ErrNotConnected) {
+            log.Println("Not connected, skipping RequestClientData")
+        } else {
+            log.Printf("RequestClientData: %v", err)
+        }
+    }
+}
+```
+
+## Method Reference
+
+| Method | Parameters | Returns | Notes |
+|--------|-----------|---------|-------|
+| `MapClientDataNameToID` | `clientDataName string, clientDataID uint32` | `error` | Called by both reader and writer; must be called first after connection |
+| `CreateClientData` | `clientDataID uint32, dwSize uint32, flags SIMCONNECT_CREATE_CLIENT_DATA_FLAG` | `error` | Writer only; `dwSize` must be 1–8192 bytes |
+| `AddToClientDataDefinition` | `defineID uint32, dwOffset uint32, dwSizeOrType uint32, epsilon float32, datumID uint32` | `error` | Call once per field; use `SIMCONNECT_CLIENTDATATYPE_*` constants for `dwSizeOrType` |
+| `RequestClientData` | `clientDataID uint32, requestID uint32, defineID uint32, period SIMCONNECT_CLIENT_DATA_PERIOD, flags SIMCONNECT_CLIENT_DATA_REQUEST_FLAG, origin uint32, interval uint32, limit uint32` | `error` | Reader only; `requestID` must be in user range |
+| `SetClientData` | `clientDataID uint32, defineID uint32, flags uint32, dwReserved uint32, cbUnitSize uint32, data unsafe.Pointer` | `error` | Writer only; `flags` and `dwReserved` must both be `0` |
+| `ClearClientDataDefinition` | `defineID uint32` | `error` | Removes all field definitions for the given define ID |
+
+`MapClientDataNameToID` is defined directly on the `Manager` interface alongside the CDA methods. All six methods are available without calling `mgr.Client()`.
+
+## ErrNotConnected
+
+Every method in this table returns `manager.ErrNotConnected` if called when the manager has no active connection. This includes the period between startup and the first successful connection, and any reconnection gap when auto-reconnect is enabled.
+
+```go
+if err := mgr.CreateClientData(...); err != nil {
+    if errors.Is(err, manager.ErrNotConnected) {
+        // Not yet connected — defer setup to the OnConnectionStateChange handler
+        return
+    }
+    log.Printf("CreateClientData failed: %v", err)
+}
+```
+
+The manager does not queue or retry failed calls. Register your CDA setup inside `OnConnectionStateChange` or `SubscribeOnOpen` so it runs automatically on each (re)connection.
+
+## ID Range
+
+The `requestID` parameter in `RequestClientData` must be within the user range: **1 to 999,999,849**. The manager reserves 999,999,850–999,999,999 for internal use.
+
+Use `manager.IsValidUserID(id)` to validate an ID before use:
+
+```go
+const WeatherReqID uint32 = 1002
+
+if !manager.IsValidUserID(WeatherReqID) {
+    log.Fatal("ID conflicts with manager reserved range")
+}
+```
+
+See [Request and ID Management](manager-requests-ids.md) for the complete ID allocation table and validation helpers.
+
+## See Also
+
+- [Client Data Areas](client-data-area.md) — Engine-layer reference: types, constants (`SIMCONNECT_CLIENTDATATYPE_*`, `SIMCONNECT_CLIENT_DATA_PERIOD`, `SIMCONNECT_CLIENT_DATA_REQUEST_FLAG`), and complete writer/reader examples
+- [Manager Usage](usage-manager.md) — Full manager API reference including subscriptions and connection lifecycle
+- [Request and ID Management](manager-requests-ids.md) — ID allocation strategy and conflict prevention

--- a/docs/manager-input-events.md
+++ b/docs/manager-input-events.md
@@ -1,0 +1,328 @@
+---
+title: "Input Events (Manager)"
+section: "manager"
+order: 7
+---
+
+# Input Events (Manager)
+
+The `manager` package exposes the full SimConnect Input Event API as direct methods on the `Manager` interface. This guide covers enumeration, value reads and writes, subscriptions, and cleanup through the manager's lifecycle-managed connection.
+
+> **MSFS 2024 only.** The Input Event API is not present in the MSFS 2020 SimConnect SDK. All six methods (`EnumerateInputEvents`, `GetInputEvent`, `SetInputEventDouble`, `SetInputEventString`, `SubscribeInputEvent`, `UnsubscribeInputEvent`) will return an error when called against an MSFS 2020 installation.
+
+> **See also:** [Input Events](guide-input-events.md) for the engine-layer reference covering message types, descriptor fields, wire layout details, and value extraction helpers.
+
+## Overview
+
+Input Events are hash-addressed simulator bindings that map to physical cockpit interactions — button states, switch positions, knob values. They differ from system events (which signal lifecycle changes like pause or crash) and from SimVars (which describe simulation world state). Input Events represent the raw input layer that the simulator uses internally to trigger avionics logic.
+
+You cannot assume a fixed set of Input Events. The available set depends on the aircraft loaded and the simulator build. Enumerate at runtime to discover what is present, then use the hash to read, write, or subscribe.
+
+## How Input Event Hashes Work
+
+Each input event is identified by a hash. There are two representations:
+
+- **Descriptor hash** (`SIMCONNECT_INPUT_EVENT_DESCRIPTOR.Hash`) — a 32-bit value returned during enumeration. Cast it to `uint64` when passing to any method: `uint64(desc.Hash)`.
+- **Subscription notification hash** — the full 64-bit hash carried in `SIMCONNECT_RECV_SUBSCRIBE_INPUT_EVENT`. Extract it with `engine.SubscribeInputEventHash(recv)` rather than reading the raw bytes directly.
+
+Hashes are stable for the duration of a simulator session. They may change between sessions or after loading a different aircraft. Enumerate again whenever the aircraft or simulator state changes if you need to maintain an accurate hash map.
+
+## Workflow
+
+### Step 1 — Enumerate available input events
+
+Call `EnumerateInputEvents` with a request ID. The simulator responds with one or more `SIMCONNECT_RECV_ID_ENUMERATE_INPUT_EVENTS` messages, each carrying a batch of descriptors.
+
+```go
+const EnumReqID uint32 = 1000
+
+mgr.OnConnectionStateChange(func(old, new manager.ConnectionState) {
+    if new != manager.StateConnected {
+        return
+    }
+    if err := mgr.EnumerateInputEvents(EnumReqID); err != nil {
+        log.Printf("EnumerateInputEvents failed: %v", err)
+    }
+})
+```
+
+### Step 2 — Handle enumeration responses
+
+Subscribe to the `SIMCONNECT_RECV_ID_ENUMERATE_INPUT_EVENTS` message type and read the descriptor batch:
+
+```go
+sub := mgr.SubscribeWithFilter("input-enum", 50, func(msg engine.Message) bool {
+    return types.SIMCONNECT_RECV_ID(msg.DwID) == types.SIMCONNECT_RECV_ID_ENUMERATE_INPUT_EVENTS
+})
+defer sub.Unsubscribe()
+
+go func() {
+    for {
+        select {
+        case msg := <-sub.Messages():
+            recv := msg.AsEnumerateInputEvents()
+            if recv == nil {
+                continue
+            }
+            count := int(recv.DwArraySize)
+            for i := 0; i < count; i++ {
+                desc := recv.RgData[i]
+                name := engine.BytesToString(desc.Name[:])
+                log.Printf("Event: %-64s  hash=0x%08X  type=%d", name, desc.Hash, desc.Type)
+            }
+        case <-sub.Done():
+            return
+        }
+    }
+}()
+```
+
+### Step 3 — Subscribe to change notifications
+
+Once you have the hash of an event you want to track, call `SubscribeInputEvent`. The simulator will push a notification every time the event value changes.
+
+```go
+var eventHash uint64 = 0x00000001 // replace with hash from enumeration
+
+if err := mgr.SubscribeInputEvent(eventHash); err != nil {
+    log.Printf("SubscribeInputEvent failed: %v", err)
+}
+```
+
+### Step 4 — Request the current value
+
+To read the current value once, call `GetInputEvent`. The response arrives as a `SIMCONNECT_RECV_ID_GET_INPUT_EVENT` message.
+
+```go
+const GetReqID uint32 = 1001
+
+if err := mgr.GetInputEvent(GetReqID, eventHash); err != nil {
+    log.Printf("GetInputEvent failed: %v", err)
+}
+```
+
+Receive the response:
+
+```go
+sub := mgr.SubscribeWithFilter("input-get", 10, func(msg engine.Message) bool {
+    return types.SIMCONNECT_RECV_ID(msg.DwID) == types.SIMCONNECT_RECV_ID_GET_INPUT_EVENT
+})
+defer sub.Unsubscribe()
+
+go func() {
+    for msg := range sub.Messages() {
+        recv := msg.AsGetInputEvent()
+        if recv == nil || uint32(recv.RequestID) != GetReqID {
+            continue
+        }
+        if f, ok := engine.InputEventValueAsFloat64(recv); ok {
+            log.Printf("Value (float64): %f", f)
+        }
+        if s, ok := engine.InputEventValueAsString(recv); ok {
+            log.Printf("Value (string): %s", s)
+        }
+    }
+}()
+```
+
+### Step 5 — Set a value
+
+Write a new value using `SetInputEventDouble` for numeric events or `SetInputEventString` for string-typed events. Both are fire-and-forget — no response message is sent.
+
+```go
+// Write a numeric value
+if err := mgr.SetInputEventDouble(eventHash, 1.0); err != nil {
+    log.Printf("SetInputEventDouble failed: %v", err)
+}
+
+// Write a string value (strings longer than 259 bytes are silently truncated)
+if err := mgr.SetInputEventString(eventHash, "AUTOPILOT_ON"); err != nil {
+    log.Printf("SetInputEventString failed: %v", err)
+}
+```
+
+### Step 6 — Unsubscribe
+
+When you no longer need change notifications for an event, call `UnsubscribeInputEvent` with the same hash.
+
+```go
+if err := mgr.UnsubscribeInputEvent(eventHash); err != nil {
+    log.Printf("UnsubscribeInputEvent failed: %v", err)
+}
+```
+
+## Complete Example
+
+The following example connects via manager, enumerates input events on each connection, subscribes to the first event found, and prints change notifications.
+
+```go
+//go:build windows
+
+package main
+
+import (
+    "errors"
+    "log"
+    "os"
+    "os/signal"
+    "sync/atomic"
+
+    "github.com/mrlm-net/simconnect"
+    "github.com/mrlm-net/simconnect/pkg/engine"
+    "github.com/mrlm-net/simconnect/pkg/manager"
+    "github.com/mrlm-net/simconnect/pkg/types"
+)
+
+const (
+    EnumReqID uint32 = 1000
+    GetReqID  uint32 = 1001
+)
+
+var subscribedHash atomic.Uint64
+
+func main() {
+    mgr := simconnect.New("InputEventDemo",
+        manager.WithAutoReconnect(true),
+    )
+
+    // Enumerate on every (re)connection
+    mgr.OnOpen(func(data *types.SIMCONNECT_RECV_OPEN) {
+        subscribedHash.Store(0)
+        if err := mgr.EnumerateInputEvents(EnumReqID); err != nil {
+            if errors.Is(err, manager.ErrNotConnected) {
+                return
+            }
+            log.Printf("EnumerateInputEvents: %v", err)
+        }
+    })
+
+    // Handle enumeration and subscription change messages
+    sub := mgr.Subscribe("input-events", 50)
+    defer sub.Unsubscribe()
+
+    go func() {
+        for {
+            select {
+            case msg := <-sub.Messages():
+                handleMessage(mgr, msg)
+            case <-sub.Done():
+                return
+            }
+        }
+    }()
+
+    sigChan := make(chan os.Signal, 1)
+    signal.Notify(sigChan, os.Interrupt)
+    go func() {
+        <-sigChan
+        mgr.Stop()
+    }()
+
+    if err := mgr.Start(); err != nil {
+        log.Printf("Manager stopped: %v", err)
+    }
+}
+
+func handleMessage(mgr manager.Manager, msg engine.Message) {
+    switch types.SIMCONNECT_RECV_ID(msg.DwID) {
+
+    case types.SIMCONNECT_RECV_ID_ENUMERATE_INPUT_EVENTS:
+        recv := msg.AsEnumerateInputEvents()
+        if recv == nil {
+            return
+        }
+        count := int(recv.DwArraySize)
+        for i := 0; i < count; i++ {
+            desc := recv.RgData[i]
+            name := engine.BytesToString(desc.Name[:])
+            log.Printf("Event: %-64s  hash=0x%08X  type=%d", name, desc.Hash, desc.Type)
+            // Subscribe to the first event found in the first batch
+            if i == 0 && recv.DwEntryNumber == 0 && subscribedHash.Load() == 0 {
+                h := uint64(desc.Hash)
+                if err := mgr.SubscribeInputEvent(h); err == nil {
+                    subscribedHash.Store(h)
+                    log.Printf("Subscribed to %s (0x%016X)", name, h)
+                }
+            }
+        }
+
+    case types.SIMCONNECT_RECV_ID_SUBSCRIBE_INPUT_EVENT:
+        recv := msg.AsSubscribeInputEvent()
+        if recv == nil {
+            return
+        }
+        hash := engine.SubscribeInputEventHash(recv)
+        if f, ok := engine.SubscribeInputEventValueAsFloat64(recv); ok {
+            log.Printf("Event 0x%016X changed → %f", hash, f)
+        }
+        if s, ok := engine.SubscribeInputEventValueAsString(recv); ok {
+            log.Printf("Event 0x%016X changed → %s", hash, s)
+        }
+
+    case types.SIMCONNECT_RECV_ID_EXCEPTION:
+        recv := msg.AsException()
+        if recv != nil {
+            log.Printf("SimConnect exception: %d", recv.DwException)
+        }
+    }
+}
+```
+
+## Method Reference
+
+| Method | Parameters | Returns | Notes |
+|--------|-----------|---------|-------|
+| `EnumerateInputEvents` | `requestID uint32` | `error` | Triggers one or more `SIMCONNECT_RECV_ID_ENUMERATE_INPUT_EVENTS` response messages |
+| `GetInputEvent` | `requestID uint32, hash uint64` | `error` | Async — response arrives as `SIMCONNECT_RECV_ID_GET_INPUT_EVENT` |
+| `SetInputEventDouble` | `hash uint64, value float64` | `error` | Fire-and-forget; no response message |
+| `SetInputEventString` | `hash uint64, value string` | `error` | Fire-and-forget; strings over 259 bytes are silently truncated |
+| `SubscribeInputEvent` | `hash uint64` | `error` | Change notifications arrive as `SIMCONNECT_RECV_ID_SUBSCRIBE_INPUT_EVENT` |
+| `UnsubscribeInputEvent` | `hash uint64` | `error` | Cancels the active subscription for the given hash |
+
+## Double vs String
+
+Use `SetInputEventDouble` for the vast majority of sim controls. Most Input Events are numeric — switch states (0.0 or 1.0), throttle positions (0.0–1.0), heading values, and similar. If `SIMCONNECT_INPUT_EVENT_DESCRIPTOR.Type` is `SIMCONNECT_INPUT_EVENT_TYPE_DOUBLE`, use the double setter.
+
+Use `SetInputEventString` only when `Type` is `SIMCONNECT_INPUT_EVENT_TYPE_STRING`. String-typed events are rare and typically represent text-mode commands or named state identifiers in specialised aircraft implementations. Strings longer than 259 bytes are silently truncated on the DLL side to preserve the null terminator.
+
+When in doubt, check the `Type` field from the enumeration descriptor before setting a value.
+
+## No Auto-Resubscribe on Reconnect
+
+Input Event subscriptions are not restored automatically when the manager reconnects to the simulator. The SimConnect session is fully reset on each connection — all previously registered subscriptions, enumerations, and hash-to-event mappings are gone.
+
+You must resubscribe in your `OnOpen` handler:
+
+```go
+mgr.OnOpen(func(data *types.SIMCONNECT_RECV_OPEN) {
+    // Re-enumerate to rediscover hashes for the current session
+    if err := mgr.EnumerateInputEvents(EnumReqID); err != nil {
+        log.Printf("EnumerateInputEvents: %v", err)
+    }
+    // Re-subscribe once you have valid hashes from the enumeration response
+})
+```
+
+Do not cache hashes across reconnections. Hashes are session-scoped and may differ after an aircraft reload or simulator restart.
+
+## ErrNotConnected
+
+Every method returns `manager.ErrNotConnected` when the manager has no active connection. This covers the startup window before the first successful connection and any reconnection gap.
+
+```go
+if err := mgr.EnumerateInputEvents(EnumReqID); err != nil {
+    if errors.Is(err, manager.ErrNotConnected) {
+        // Not yet connected — will retry from OnOpen handler
+        return
+    }
+    log.Printf("EnumerateInputEvents failed: %v", err)
+}
+```
+
+The manager does not queue or retry failed calls. Register your Input Event setup inside `OnOpen` so it runs automatically on each connection.
+
+## See Also
+
+- [Input Events](guide-input-events.md) — Engine-layer reference: descriptor fields, wire layout notes, hash extraction helpers, and complete enumeration/subscribe examples using the raw client
+- [Manager Usage](usage-manager.md) — Full manager API reference including subscriptions and connection lifecycle
+- [Request and ID Management](manager-requests-ids.md) — ID allocation strategy; `requestID` in `EnumerateInputEvents` and `GetInputEvent` must be in the user range (1–999,999,849)


### PR DESCRIPTION
## Summary

Adds two manager-layer documentation pages to complement the existing engine-layer guides:

- **`docs/manager-client-data-area.md`** (#241): CDA workflow (MapClientDataNameToID → CreateClientData → AddToClientDataDefinition → RequestClientData → read channel → SetClientData → ClearClientDataDefinition), method reference table for all 5 methods, ErrNotConnected guidance, ID range cross-link to `manager-requests-ids.md`, complete Go code example
- **`docs/manager-input-events.md`** (#242): Input Event enumeration workflow, method reference table for all 6 methods, Double vs String guidance, no-auto-resubscribe note, MSFS 2024-only callout, complete Go code example

Also adds cross-reference links from the engine-layer docs (`docs/client-data-area.md` and `docs/guide-input-events.md`) to the new manager counterparts.

## Navigation

Both pages use `section: "manager"` frontmatter — auto-discovered by the SvelteKit pipeline. No changes to `navigation.ts` required.

- `manager-client-data-area.md` → order: 6
- `manager-input-events.md` → order: 7

## Test Plan

- [x] Frontmatter `section: "manager"` and `order` values set correctly
- [x] All Go code examples use only `pkg/manager` public API
- [x] No duplicate order values in manager section (existing: config=1, usage=2, api=3, requests-ids=5)
- [x] Cross-references to engine-layer docs added

Closes #241
Closes #242