### PR TITLE
fix(internal): fix unsafe.Pointer lifetime in stringToBytePtr (#260)

### DIFF
--- a/internal/simconnect/connection.go
+++ b/internal/simconnect/connection.go
@@ -4,6 +4,7 @@ package simconnect
 
 import (
 	"fmt"
+	"unsafe"
 )
 
 func (sc *SimConnect) Connect() error {
@@ -16,8 +17,8 @@ func (sc *SimConnect) Connect() error {
 	procedure := sc.library.LoadProcedure("SimConnect_Open")
 
 	hresult, _, _ := procedure.Call(
-		sc.getConnectionPtr(), // phSimConnect - pointer to connection handle
-		szName,                // szName
+		sc.getConnectionPtr(),            // phSimConnect - pointer to connection handle
+		uintptr(unsafe.Pointer(szName)), // szName
 		0,                     // hWnd (NULL)
 		0,                     // UserEventWin32
 		0,                     // hEventHandle

--- a/internal/simconnect/data.go
+++ b/internal/simconnect/data.go
@@ -68,8 +68,8 @@ func (sc *SimConnect) AddToDataDefinition(definitionID uint32, datumName string,
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
 		uintptr(definitionID),
-		szDatumName,
-		szUnitsName,
+		uintptr(unsafe.Pointer(szDatumName)),
+		uintptr(unsafe.Pointer(szUnitsName)),
 		uintptr(datumType),
 		uintptr(*(*uint32)(unsafe.Pointer(&epsilon))), // float32 to uintptr conversion
 		uintptr(datumID),

--- a/internal/simconnect/event.go
+++ b/internal/simconnect/event.go
@@ -5,6 +5,7 @@ package simconnect
 
 import (
 	"fmt"
+	"unsafe"
 
 	"github.com/mrlm-net/simconnect/pkg/types"
 )
@@ -21,7 +22,7 @@ func (sc *SimConnect) MapClientEventToSimEvent(eventID uint32, eventName string)
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
 		uintptr(eventID),
-		eventNamePtr,
+		uintptr(unsafe.Pointer(eventNamePtr)),
 	)
 
 	if !isHRESULTSuccess(hresult) {
@@ -103,7 +104,7 @@ func (sc *SimConnect) MapClientDataNameToID(clientDataName string, clientDataID 
 
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
-		clientDataNamePtr,
+		uintptr(unsafe.Pointer(clientDataNamePtr)),
 		uintptr(clientDataID),
 	)
 

--- a/internal/simconnect/facility.go
+++ b/internal/simconnect/facility.go
@@ -22,7 +22,7 @@ func (sc *SimConnect) AddToFacilityDefinition(definitionID uint32, fieldName str
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
 		uintptr(definitionID),
-		szFieldName,
+		uintptr(unsafe.Pointer(szFieldName)),
 	)
 
 	if !isHRESULTSuccess(hresult) {
@@ -43,7 +43,7 @@ func (sc *SimConnect) AddFacilityDataDefinitionFilter(definitionID uint32, filte
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
 		uintptr(definitionID),
-		szFilterPath,
+		uintptr(unsafe.Pointer(szFilterPath)),
 		uintptr(filterDataSize),
 		uintptr(filterData),
 	)
@@ -121,8 +121,8 @@ func (sc *SimConnect) RequestFacilityData(definitionID uint32, requestID uint32,
 		sc.getConnection(), // phSimConnect - pointer to handle
 		uintptr(definitionID),
 		uintptr(requestID),
-		szICAO,
-		szRegion,
+		uintptr(unsafe.Pointer(szICAO)),
+		uintptr(unsafe.Pointer(szRegion)),
 	)
 
 	if !isHRESULTSuccess(hresult) {
@@ -150,8 +150,8 @@ func (sc *SimConnect) RequestFacilityDataEX1(definitionID uint32, requestID uint
 		sc.getConnection(), // phSimConnect - pointer to handle
 		uintptr(definitionID),
 		uintptr(requestID),
-		szICAO,
-		szRegion,
+		uintptr(unsafe.Pointer(szICAO)),
+		uintptr(unsafe.Pointer(szRegion)),
 		uintptr(facilityType),
 	)
 
@@ -173,7 +173,7 @@ func (sc *SimConnect) RequestJetwayData(airportICAO string, arrayCount uint32, i
 
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
-		szAirportICAO,
+		uintptr(unsafe.Pointer(szAirportICAO)),
 		uintptr(arrayCount),
 		uintptr(unsafe.Pointer(indexes)),
 	)

--- a/internal/simconnect/flight.go
+++ b/internal/simconnect/flight.go
@@ -3,7 +3,10 @@
 
 package simconnect
 
-import "fmt"
+import (
+	"fmt"
+	"unsafe"
+)
 
 // https://docs.flightsimulator.com/msfs2024/html/6_Programming_APIs/SimConnect/API_Reference/Flights/SimConnect_FlightLoad.htm
 func (sc *SimConnect) FlightLoad(flightFile string) error {
@@ -16,7 +19,7 @@ func (sc *SimConnect) FlightLoad(flightFile string) error {
 
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
-		szFlightFile,
+		uintptr(unsafe.Pointer(szFlightFile)),
 	)
 
 	if !isHRESULTSuccess(hresult) {
@@ -47,9 +50,9 @@ func (sc *SimConnect) FlightSave(flightFile string, title string, description st
 
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
-		szFlightFile,
-		szTitle,
-		szDescription,
+		uintptr(unsafe.Pointer(szFlightFile)),
+		uintptr(unsafe.Pointer(szTitle)),
+		uintptr(unsafe.Pointer(szDescription)),
 		0, // reserved - must be zero
 	)
 
@@ -71,7 +74,7 @@ func (sc *SimConnect) FlightPlanLoad(flightPlanFile string) error {
 
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
-		szFlightPlanFile,
+		uintptr(unsafe.Pointer(szFlightPlanFile)),
 	)
 
 	if !isHRESULTSuccess(hresult) {

--- a/internal/simconnect/helpers.go
+++ b/internal/simconnect/helpers.go
@@ -9,17 +9,8 @@ import (
 	"github.com/mrlm-net/simconnect/pkg/types"
 )
 
-func stringToBytePtr(name string) (uintptr, error) {
-	// Use syscall.BytePtrFromString to convert the string to a null-terminated byte array
-	// This is necessary for compatibility with the SimConnect API which expects a pointer to a null-terminated string.
-	// Convert name to null-terminated byte array
-	nameBytes, err := syscall.BytePtrFromString(name)
-
-	if err != nil {
-		return 0, err // Return 0 for uintptr if conversion fails
-	}
-
-	return uintptr(unsafe.Pointer(nameBytes)), nil // Convert the byte array to a uintptr pointer
+func stringToBytePtr(name string) (*byte, error) {
+	return syscall.BytePtrFromString(name)
 }
 
 func isHRESULTSuccess(hresult uintptr) bool {

--- a/internal/simconnect/object-ai.go
+++ b/internal/simconnect/object-ai.go
@@ -38,10 +38,10 @@ func (sc *SimConnect) AICreateEnrouteATCAircraft(szContainerTitle string, szTail
 
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
-		szContainerTitlePtr,
-		szTailNumberPtr,
+		uintptr(unsafe.Pointer(szContainerTitlePtr)),
+		uintptr(unsafe.Pointer(szTailNumberPtr)),
 		uintptr(iFlightNumber),
-		szFlightPlanPathPtr,
+		uintptr(unsafe.Pointer(szFlightPlanPathPtr)),
 		uintptr(unsafe.Pointer(&dFlightPlanPosition)),
 		bTouchAndGoUintptr,
 		uintptr(RequestID),
@@ -70,8 +70,8 @@ func (sc *SimConnect) AICreateNonATCAircraft(szContainerTitle string, szTailNumb
 
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
-		szContainerTitlePtr,
-		szTailNumberPtr,
+		uintptr(unsafe.Pointer(szContainerTitlePtr)),
+		uintptr(unsafe.Pointer(szTailNumberPtr)),
 		uintptr(unsafe.Pointer(&initPos)),
 		uintptr(RequestID),
 	)
@@ -104,9 +104,9 @@ func (sc *SimConnect) AICreateParkedATCAircraft(szContainerTitle string, szTailN
 
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
-		szContainerTitlePtr,
-		szTailNumberPtr,
-		szAirportIDPtr,
+		uintptr(unsafe.Pointer(szContainerTitlePtr)),
+		uintptr(unsafe.Pointer(szTailNumberPtr)),
+		uintptr(unsafe.Pointer(szAirportIDPtr)),
 		uintptr(RequestID),
 	)
 
@@ -129,7 +129,7 @@ func (sc *SimConnect) AISetAircraftFlightPlan(objectID uint32, szFlightPlanPath 
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
 		uintptr(objectID),
-		szFlightPlanPathPtr,
+		uintptr(unsafe.Pointer(szFlightPlanPathPtr)),
 		uintptr(requestID),
 	)
 
@@ -167,11 +167,11 @@ func (sc *SimConnect) AICreateEnrouteATCAircraftEX1(szContainerTitle string, szL
 	procedure := sc.library.LoadProcedure("SimConnect_AICreateEnrouteATCAircraft_EX1")
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
-		szContainerTitlePtr,
-		szLiveryPtr,
-		szTailNumberPtr,
+		uintptr(unsafe.Pointer(szContainerTitlePtr)),
+		uintptr(unsafe.Pointer(szLiveryPtr)),
+		uintptr(unsafe.Pointer(szTailNumberPtr)),
 		uintptr(iFlightNumber),
-		szFlightPlanPathPtr,
+		uintptr(unsafe.Pointer(szFlightPlanPathPtr)),
 		uintptr(unsafe.Pointer(&dFlightPlanPosition)),
 		bTouchAndGoUintptr,
 		uintptr(RequestID),
@@ -200,9 +200,9 @@ func (sc *SimConnect) AICreateNonATCAircraftEX1(szContainerTitle string, szLiver
 
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
-		szContainerTitlePtr,
-		szLiveryPtr,
-		szTailNumberPtr,
+		uintptr(unsafe.Pointer(szContainerTitlePtr)),
+		uintptr(unsafe.Pointer(szLiveryPtr)),
+		uintptr(unsafe.Pointer(szTailNumberPtr)),
 		uintptr(unsafe.Pointer(&initPos)),
 		uintptr(RequestID),
 	)
@@ -234,10 +234,10 @@ func (sc *SimConnect) AICreateParkedATCAircraftEX1(szContainerTitle string, szLi
 
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
-		szContainerTitlePtr,
-		szLiveryPtr,
-		szTailNumberPtr,
-		szAirportIDPtr,
+		uintptr(unsafe.Pointer(szContainerTitlePtr)),
+		uintptr(unsafe.Pointer(szLiveryPtr)),
+		uintptr(unsafe.Pointer(szTailNumberPtr)),
+		uintptr(unsafe.Pointer(szAirportIDPtr)),
 		uintptr(RequestID),
 	)
 	if !isHRESULTSuccess(hresult) {

--- a/internal/simconnect/object.go
+++ b/internal/simconnect/object.go
@@ -20,7 +20,7 @@ func (sc *SimConnect) AICreateSimulatedObject(szContainerTitle string, initPos t
 	procedure := sc.library.LoadProcedure("SimConnect_AICreateSimulatedObject")
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
-		szContainerTitlePtr,
+		uintptr(unsafe.Pointer(szContainerTitlePtr)),
 		uintptr(unsafe.Pointer(&initPos)),
 		uintptr(RequestID),
 	)
@@ -92,8 +92,8 @@ func (sc *SimConnect) AICreateSimulatedObjectEX1(szContainerTitle string, szLive
 
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
-		szContainerTitlePtr,
-		szLiveryPtr,
+		uintptr(unsafe.Pointer(szContainerTitlePtr)),
+		uintptr(unsafe.Pointer(szLiveryPtr)),
 		uintptr(unsafe.Pointer(&initPos)),
 		uintptr(RequestID),
 	)

--- a/internal/simconnect/system.go
+++ b/internal/simconnect/system.go
@@ -5,6 +5,7 @@ package simconnect
 
 import (
 	"fmt"
+	"unsafe"
 
 	"github.com/mrlm-net/simconnect/pkg/types"
 )
@@ -26,7 +27,7 @@ func (sc *SimConnect) RequestSystemState(requestID uint32, state types.SIMCONNEC
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
 		uintptr(requestID), // Explicit cast
-		szState,
+		uintptr(unsafe.Pointer(szState)),
 	)
 
 	if !isHRESULTSuccess(hresult) {
@@ -48,7 +49,7 @@ func (sc *SimConnect) SubscribeToSystemEvent(eventID uint32, eventName string) e
 	hresult, _, _ := procedure.Call(
 		sc.getConnection(), // phSimConnect - pointer to handle
 		uintptr(eventID),
-		szEventName,
+		uintptr(unsafe.Pointer(szEventName)),
 	)
 
 	if !isHRESULTSuccess(hresult) {


### PR DESCRIPTION
## Summary
- Changes `stringToBytePtr` in `internal/simconnect/helpers.go` to return `(*byte, error)` instead of `(uintptr, error)`
- Updates all 9 call-site files to convert inline: `uintptr(unsafe.Pointer(ptr))` directly within `procedure.Call(...)` argument lists
- Eliminates CWE-825 (use of pointer after end of lifetime) — the previous code converted to `uintptr` across a function boundary, allowing the GC to collect the backing allocation between conversion and use
- Adds `"unsafe"` import to `connection.go`, `flight.go`, `system.go`, `event.go` which previously lacked it

## Test plan
- [ ] `go build ./...` passes
- [ ] `go vet -unsafeptr=false ./...` passes
- [ ] All existing tests pass

Closes #260